### PR TITLE
docs: add /review-pr documentation and README validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,38 @@ Skipped Items (3):
 📊 Summary: 2 addressed, 3 skipped, 2 files modified
 ```
 
+### `/review-pr`
+
+Comprehensive PR review with detailed analysis and actionable feedback.
+
+**Usage:**
+```bash
+/review-pr 123                              # Review PR by number
+/review-pr https://github.com/owner/repo/pull/456  # Review by URL
+/review-pr owner/repo#789                   # Review with repo context
+```
+
+**What it does:**
+
+1. **Fetches PR data**: Downloads PR details, diff, comments, and CI status using `gh` CLI
+2. **Checks out branch**: Switches to PR branch for local analysis
+3. **Analyzes changes**: Reviews all modified files, commit history, and diff
+4. **Reviews discussions**: Examines comments, unresolved threads, and CI results
+5. **Generates report**: Provides structured review with executive summary, code quality analysis, file-by-file feedback
+
+**Review output includes:**
+- **Executive Summary**: Purpose, scope, risk level, recommendation (Approve/Request Changes)
+- **Code Quality Analysis**: Architecture, style, testing, documentation, error handling, security
+- **File-by-File Review**: Detailed feedback for each changed file
+- **Discussion Review**: Unresolved conversations, CI status, action items
+- **Recommendations**: Must fix, should fix, consider, and praise items
+
+**Safety checks:**
+- Warns about uncommitted changes before checkout
+- Requires GitHub CLI authentication
+- Respects repository permissions
+- Checks project conventions (CONTRIBUTING.md, PR templates)
+
 ## Agents
 
 ### `ci-log-analyzer`
@@ -300,7 +332,10 @@ github-plugin/
 ├── .github/workflows/
 │   └── validate-plugin.yml      # CI validation
 ├── commands/
-│   └── fix-ci.md                # Main CI fixing command
+│   ├── fix-ci.md                # CI fixing command
+│   ├── create-pr.md             # PR creation command
+│   ├── address-pr-comments.md   # PR comment resolution
+│   └── review-pr.md             # PR review command
 ├── agents/
 │   ├── ci-log-analyzer.md       # Log parsing agent
 │   └── ci-error-fixer.md        # Error fixing agent

--- a/scripts/validate-plugin.ts
+++ b/scripts/validate-plugin.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 import { z } from 'zod';
-import { readFile } from 'fs/promises';
+import { readFile, readdir } from 'fs/promises';
 import { join } from 'path';
+import { existsSync } from 'fs';
 
 const PluginManifestSchema = z.object({
   name: z.string(),
@@ -51,4 +52,75 @@ async function validatePlugin() {
   }
 }
 
-validatePlugin();
+async function validateReadmeCommands() {
+  const commandsDir = join(process.cwd(), 'commands');
+  const readmePath = join(process.cwd(), 'README.md');
+
+  if (!existsSync(commandsDir)) {
+    console.log('ℹ️  No commands directory found, skipping README validation');
+    return;
+  }
+
+  if (!existsSync(readmePath)) {
+    console.log('ℹ️  No README.md found, skipping README validation');
+    return;
+  }
+
+  try {
+    // Get actual command files
+    const commandFiles = await readdir(commandsDir);
+    const actualCommands = commandFiles
+      .filter(file => file.endsWith('.md'))
+      .map(file => file.replace('.md', ''))
+      .sort();
+
+    // Parse README to find documented commands
+    const readmeContent = await readFile(readmePath, 'utf-8');
+    const commandHeaderRegex = /^### `\/([a-z_-]+)`/gm;
+    const documentedCommands: string[] = [];
+    let match;
+
+    while ((match = commandHeaderRegex.exec(readmeContent)) !== null) {
+      documentedCommands.push(match[1]);
+    }
+
+    documentedCommands.sort();
+
+    // Compare
+    const missingInReadme = actualCommands.filter(cmd => !documentedCommands.includes(cmd));
+    const extraInReadme = documentedCommands.filter(cmd => !actualCommands.includes(cmd));
+
+    let hasErrors = false;
+
+    if (missingInReadme.length > 0) {
+      console.error('❌ Commands exist but not documented in README.md:');
+      missingInReadme.forEach(cmd => console.error(`   - /${cmd}`));
+      hasErrors = true;
+    }
+
+    if (extraInReadme.length > 0) {
+      console.error('❌ Commands documented in README.md but files don\'t exist:');
+      extraInReadme.forEach(cmd => console.error(`   - /${cmd} (missing commands/${cmd}.md)`));
+      hasErrors = true;
+    }
+
+    if (!hasErrors) {
+      console.log(`✅ README.md documents all ${actualCommands.length} commands correctly`);
+    } else {
+      process.exit(1);
+    }
+
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('❌ Error validating README commands:', error.message);
+    }
+    process.exit(1);
+  }
+}
+
+async function main() {
+  await validatePlugin();
+  await validateReadmeCommands();
+}
+
+main();


### PR DESCRIPTION
## Summary

- Added comprehensive `/review-pr` command documentation
- Updated project structure to list all 4 commands
- Added `validateReadmeCommands()` to prevent future documentation drift
- Validation ensures all commands in `commands/` directory are documented in README
- Build fails if mismatch detected

## Changes

- **README.md**: 
  - Added complete `/review-pr` command documentation with usage examples
  - Updated project structure section to show all commands
- **scripts/validate-plugin.ts**: Added README validation function

## Test Results

```
✅ github v1.2.0 is valid
✅ README.md documents all 4 commands correctly
```

## Impact

- `/review-pr` command is now properly documented for users
- Future command additions/removals will fail validation unless README is updated, preventing documentation drift