### PR TITLE
docs(create-pr): simplify and clarify command instructions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "GitHub CI/CD automation plugin for auto-detecting, analyzing, and fixing CI/CD failures on any branch",
   "author": {
     "name": "Ladislav Martincik",

--- a/commands/create-pr.md
+++ b/commands/create-pr.md
@@ -21,20 +21,18 @@ plan_file: $2
     - `bug: #456 - Fix login validation error`
     - `chore: #789 - Update dependencies`
 - The PR body should include:
-  - A summary section with the issue context
+  - A summary section explaining the **why** and context
   - Link to the implementation plan file
   - Reference to the issue (Closes #<issue_number>)
-  - A checklist of what was done
-  - A summary of key changes made
+  - "Review Focus" section highlighting what reviewers should pay attention to, potential gotchas, or architectural decisions
+  - "Testing Notes" section (only if there's something non-obvious beyond CI checks)
 
 ## Run
 
-1. Run `git diff origin/main...HEAD --stat` to see a summary of changed files
-2. Run `git log origin/main..HEAD --oneline` to see the commits that will be included
-3. Run `git diff origin/main...HEAD --name-only` to get a list of changed files
-4. Run `git push -u origin <branch_name>` to push the branch
-5. Run `gh pr create --title "<pr_title>" --body "<pr_body>" --base main` to create the PR
-6. Capture the PR URL from the output
+1. Run `git log origin/main..HEAD --oneline` to understand the commits being included
+2. Run `git push -u origin <branch_name>` to push the branch
+3. Run `gh pr create --title "<pr_title>" --body "<pr_body>" --base main` to create the PR
+4. Capture the PR URL from the output
 
 ## Report
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "GitHub CI/CD automation plugin for Claude Code",
   "private": true,
   "type": "module",

--- a/scripts/validate-plugin.ts
+++ b/scripts/validate-plugin.ts
@@ -20,9 +20,7 @@ const PluginManifestSchema = z.object({
   commands: z.record(z.object({
     description: z.string().optional(),
   })).optional(),
-  agents: z.record(z.object({
-    description: z.string().optional(),
-  })).optional(),
+  agents: z.array(z.string()).optional(),
   hooks: z.union([z.string(), z.record(z.any())]).optional(),
   mcpServers: z.union([z.string(), z.record(z.any())]).optional(),
 });


### PR DESCRIPTION
## Summary

Streamlines the `/create-pr` command workflow by:
- Removing redundant git diff steps from instructions
- Clarifying the PR body structure with specific sections
- Simplifying to focus on essential operations only

## Changes

- **commands/create-pr.md**: Refined workflow instructions and added "Review Focus" and "Testing Notes" sections for better PR quality
- **Version bumps**: Updated to v1.2.1 in package.json and plugin.json
- **Validator fix**: Fixed schema to correctly accept agents as array format (was causing build failures)

## Test Plan

- [x] Plugin validation passes (`bun run validate`)
- [x] README documentation is consistent with command files
- [x] All 4 commands properly documented