### PR TITLE
fix: --swarm flag silently ignored in /review-pr and /fix-ci

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "GitHub CI/CD automation plugin with autonomous fix loops, PR workflows, and code review",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-02-10
+
+### Fixed
+
+- **`/review-pr --swarm` routing** — replaced advisory "Argument Parsing" + "Mode Selection" with imperative "CRITICAL: Route Selection" gate to force immediate branching
+- **`/fix-ci --swarm` routing** — strengthened "CRITICAL: Parse Flags First" with explicit `SWARM_MODE=true` variable and back-reference in Step 2.5 condition check
+
 ## [1.5.0] - 2026-02-09
 
 ### Added

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -8,17 +8,12 @@ You are a comprehensive PR reviewer conducting a thorough analysis of a GitHub p
 
 User provided: `$ARGUMENTS`
 
-## Argument Parsing
+## CRITICAL: Route Selection
 
-The `$ARGUMENTS` input may contain both the PR number/URL and optional mode flags. Extract the intent:
-- Identify if `--swarm` flag is present (indicates user wants parallel team review)
-- Separate the flag from the PR identifier itself
-- The PR identifier is the remaining text after flag extraction (PR number, URL, or owner/repo#number format)
+BEFORE taking any other action, check `$ARGUMENTS` for the `--swarm` flag:
 
-## Mode Selection
-
-**If user requested swarm mode** (via `--swarm` flag): Execute the **Swarm Workflow** below.
-**Otherwise**: Execute the **Standard Workflow** below.
+1. If `--swarm` IS present: remove it from the arguments (the remaining text is the PR identifier — number, URL, or owner/repo#number format), then skip directly to **Swarm Workflow**. Do NOT execute any Standard Workflow steps.
+2. If `--swarm` is NOT present: the full `$ARGUMENTS` is the PR identifier, skip directly to **Standard Workflow**. Do NOT execute any Swarm Workflow steps.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-plugin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "GitHub CI/CD automation plugin for Claude Code",
   "private": true,
   "type": "module",

--- a/skills/ci-fix-loop/SKILL.md
+++ b/skills/ci-fix-loop/SKILL.md
@@ -15,12 +15,12 @@ This skill is invoked when:
 - Multiple CI fix iterations are needed
 - User wants hands-off CI repair
 
-## Argument Parsing
+## CRITICAL: Parse Flags First
 
-The command arguments may contain optional flags that modify the fix loop behavior:
-- Extract `--swarm` flag if present (indicates user wants parallel team-based fixing)
-- Extract `--loop` or `--auto` flags (standard autonomous mode)
-- The flags can be combined with other arguments
+BEFORE proceeding to Phase 1, extract these flags from `$ARGUMENTS`:
+- `--swarm`: If present, set SWARM_MODE=true. You MUST remember this flag — it changes behavior at Step 2.5 (parallel team-based fixing).
+- `--loop` or `--auto`: Standard autonomous mode.
+- Remove all extracted flags from arguments; remaining text is additional context.
 
 ## Configuration
 
@@ -135,11 +135,11 @@ if current_errors is empty:
 
 #### Step 2.5: Apply Fixes
 
-**Condition Check**: Determine fix strategy based on error distribution and `--swarm` flag:
+**CRITICAL Condition Check**: Before applying fixes, check BOTH conditions — was `--swarm` set during flag parsing above, AND are errors in 2+ files?
 
 ```
 file_count = count of distinct files with errors
-use_swarm = (file_count >= 2) AND (--swarm flag is set)
+use_swarm = (file_count >= 2) AND (SWARM_MODE is true from "Parse Flags First" above)
 ```
 
 **If use_swarm is FALSE** (errors in single file OR --swarm not requested):


### PR DESCRIPTION
## Summary

- **`/review-pr`**: Replaced advisory "Argument Parsing" + "Mode Selection" with imperative "CRITICAL: Route Selection" gate
- **`/fix-ci` (ci-fix-loop skill)**: Strengthened "CRITICAL: Parse Flags First" with explicit `SWARM_MODE=true` variable and back-reference in Step 2.5 condition check

## Root Cause

The LLM read the command prompt top-to-bottom and started executing the first actionable section (Standard Workflow) before processing the routing gate. The weak advisory language ("If user requested swarm mode, execute Swarm Workflow below") wasn't treated as a hard stop.

## Test plan

- [ ] `/review-pr --swarm 123` triggers agent team creation and spawns 4 reviewer teammates
- [ ] `/review-pr 123` runs standard sequential review
- [ ] `/fix-ci --swarm` with 2+ file errors triggers team-based parallel fixing
- [ ] `/fix-ci --loop` runs standard serial fix loop