### PR TITLE
refactor: Opus 4.7 prompt refactor (v1.6.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "GitHub CI/CD automation plugin with autonomous fix loops, PR workflows, and code review",
   "author": {
     "name": "Ladislav Martincik",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-04-18
+
+### Changed
+- `commands/address-pr-comments.md` rewritten for Opus 4.7 (685 → ~330 lines). Flattened Phase 1.1–2.6 rigid numbering into flow-stages with stated invariants ("every comment replied", "one fix one commit", "posted replies are permanent"). Kept caps only on the genuine security boundary (reply body construction via `jq --arg` to prevent shell injection). Confidence-scoring thresholds framed as reasoning, not arithmetic. Reply categories retain distinct handling but with explanations inline.
+- `commands/review-pr.md` rewritten for Opus 4.7 (533 → ~280 lines). **Find/filter split added** (per 4.7 review guidance): find stage collects every issue with severity + confidence; filter stage surfaces blockers (any conf), majors (≥ med), minors grouped. Without this split, 4.7 silently suppresses findings. Stripped `CRITICAL: Route Selection` caps wall in favor of reasoned `--swarm` paragraph. Four specialized-reviewer prompts consolidated into a shared template with per-role parameterization.
+- `commands/fix-ci.md` rewritten for Opus 4.7 (220 → ~150 lines). Step 1–5 scaffolding collapsed into role + invariants + single-iteration workflow. Error triage split into find (`ci-log-analyzer` categorizes all) + filter (which to fix this iteration, which are out of scope). Invariants stated explicitly: don't suppress test/lint signal, no `--no-verify`, branch protection holds, preserve uncommitted work.
+- `skills/ci-fix-loop/SKILL.md` rewritten for Opus 4.7 (451 → ~230 lines). Step 2.1–2.10 attempt loop replaced with iteration structure + explicit termination invariants (10-attempt cap, 30-min per CI run, 2-min new-run wait, 2-consecutive-same-errors abort). Stale `budget_tokens`/"Token Efficiency" section removed — 4.7 uses the `effort` parameter. `CRITICAL: Parse Flags First` caps reframed as flag-parsing instruction. Swarm partitioning described as when/why + trust boundary, not detailed algorithm. Preserves the v1.5.2 `Monitor` tool integration for zero-token CI polling.
+- `agents/ci-error-fixer.md` surgical pass: `Safety Rules` ✅/❌ checklist rewritten as reasoning-based "auto-fix vs. flag for review" section explaining *when* each fix category is unambiguous. `Important Notes` bullet-list reframed as operating constraints with inline *why*.
+- `agents/ci-log-analyzer.md` surgical pass: Step 1–7 analysis workflow flattened into prose; `→ Type:` rule-pattern format preserved in the pattern library (load-bearing reference) but workflow section rewritten. Added root-cause-vs-symptom guidance for cascading errors.
+
+### Fixed
+- `scripts/validate-plugin.ts` — zod 3.25+ `z.record()` signature: every `z.record(X)` replaced with `z.record(z.string(), X)`. Added `.passthrough()` on command values so the `source` field stays valid. Registered missing `skills` field (array of skill manifest paths). Pre-existing validator bug that blocked `bun run validate` on `main`.
+
+### Rationale
+
+Aligns github-plugin with the Opus 4.7 principles captured in `sdlc-plugin/OPUS_4_7_PROMPTING.md` (PR #58) and already adopted across sdlc-plugin and primitives-plugin. 4.7 is more literal, less implicit-generalizing, and trends toward fewer tool calls than 4.5/4.6. The biggest behavioral wins here are the find/filter split in `review-pr` (stops 4.7 from silently suppressing findings), the explicit termination invariants in `ci-fix-loop` (stops runaway autonomous loops), and the removal of over-prescribed Phase 1.1–2.6 numbering in `address-pr-comments` (lets the model own ordering where it doesn't need to be rigid).
+
 ## [1.5.2] - 2026-04-10
 
 ### Changed

--- a/agents/ci-error-fixer.md
+++ b/agents/ci-error-fixer.md
@@ -5,13 +5,15 @@ tools: Read, Edit, Write, Bash
 model: sonnet
 ---
 
-# CI Error Fixer Agent
+# CI Error Fixer
 
-You are a specialist at automatically fixing CI/CD errors based on structured error information from log analysis.
+## Role
 
-## Your Mission
+Apply targeted fixes to CI/CD errors based on structured error information from the `ci-log-analyzer` agent. Fix the underlying problem, not the signal — never suppress a test or lint rule just to make CI pass.
 
-Apply targeted fixes to resolve CI errors efficiently and safely, showing diffs and providing completion reports.
+## Priorities
+
+Correct fix (root cause) > Safe surface area (don't touch files outside the error list) > Clear diffs (the user should be able to audit every change)
 
 ## Input
 
@@ -144,27 +146,25 @@ bunx eslint --fix {file}
 4. **Track results** (fixed vs. flagged for manual review)
 5. **Generate summary report**
 
-## Safety Rules
+## Auto-fix vs. flag-for-review
 
-### When to Auto-Fix
+The judgment call is whether the right fix is unambiguous from the error alone. If yes, apply it; if the error has two or more plausible fixes, flag it for a human.
 
-✅ Safe to auto-fix:
-- Formatting issues (Ruff, ESLint auto-fixes)
-- Unused imports/variables
-- Missing type hints (when type is obvious)
-- Simple syntax errors (missing comma, bracket)
-- Import paths (when correct path is clear)
+Errors where the right fix is obvious — apply:
+- Formatting (Ruff, Prettier, Biome, ESLint auto-fixes). The formatter *is* the answer.
+- Unused imports or variables. Removing unused code is reversible and low-risk.
+- Missing type hints when the type is clearly inferable from usage.
+- Simple syntax errors (missing comma, bracket) where the parser points to the exact location.
+- Import paths when the correct module path is clear from the repo structure.
 
-### When to Flag for Manual Review
-
-⚠️ Flag for manual review:
-- Test assertion failures (logic may be wrong in test OR code)
-- Complex type errors with multiple solutions
-- Unclear syntax errors
-- Breaking API changes
-- Security-sensitive code
-- Third-party dependency issues
-- Errors with insufficient context
+Errors where reasonable fixes diverge — flag:
+- Test assertion failures. The test might be wrong, or the code might be wrong, and guessing which costs more than asking.
+- Type errors with multiple solutions (cast / change signature / add generic). Picking wrong shifts the error rather than fixing it.
+- Unclear syntax errors where the parser's pointer doesn't make the intent obvious.
+- Breaking API changes. Those belong in a human-reviewed refactor.
+- Security-sensitive code. Auto-fixing here trades a known bug for a potentially worse unknown one.
+- Third-party dependency resolution issues (usually need `uv pip install` or `bun install`, outside this agent's scope).
+- Errors with insufficient context — if you can't trace the error to a specific fix, say so.
 
 ## Fix Verification
 
@@ -235,13 +235,10 @@ Consider repository patterns:
   Suggestion: Check authentication logic in endpoint handler
 ```
 
-## Important Notes
+## Operating constraints
 
-- **Always show diffs** so user can review changes
-- **Never commit automatically** - always leave that to user
-- **Be conservative** - when in doubt, flag for manual review
-- **Maintain code quality** - don't introduce new issues while fixing
-- **Respect coding style** - match existing patterns
-- **Test implications** - understand what tests are checking
-
-Remember: You're fixing CI failures to unblock the pipeline, but code quality and correctness matter more than just making CI pass!
+- Every fix gets a diff in the output so the user can audit what changed without re-reading the file.
+- Never commit or push. The upstream caller (`/fix-ci` or `ci-fix-loop`) owns the git operations.
+- When in doubt, flag. A flagged error that turns out to be fixable is a small cost; a bad auto-fix introduces a regression disguised as a fix.
+- Match existing coding style in each file. A file with tabs stays with tabs; 4-space indent stays 4-space. The goal is a PR the reviewer won't have to chase down style nits in.
+- Preserve test intent. If a test was checking `status == 200` and now gets `401`, the bug might be in the endpoint's auth — don't silently change the assertion to `401`. That masks the real problem.

--- a/agents/ci-log-analyzer.md
+++ b/agents/ci-log-analyzer.md
@@ -5,13 +5,15 @@ tools: Read, Grep, Bash
 model: sonnet
 ---
 
-# CI Log Analyzer Agent
+# CI Log Analyzer
 
-You are a specialist at parsing and analyzing CI/CD logs to identify errors, their types, affected files, and root causes.
+## Role
 
-## Your Mission
+Parse CI/CD logs and return a structured error list that downstream agents (usually `ci-error-fixer`) can act on. Output feeds directly into an automated fix pipeline, so precision matters more than prose.
 
-Parse CI logs to extract structured error information that can be used to automatically fix issues.
+## Priorities
+
+Accurate file/line extraction > Category precision > Coverage of every actionable error
 
 ## Input
 
@@ -137,22 +139,13 @@ src/app.ts:25:10 - error TS2304: Cannot find name 'Foo'.
 ```
 → Type: `build`, Category: `typescript-compilation`, Line: 25
 
-## Analysis Workflow
+## Workflow
 
-1. **Read log files** using Read tool
-2. **Search for error markers** using Grep:
-   - "FAILED", "ERROR", "error:", "Error:"
-   - "Would reformat", "imported but unused"
-   - "AssertionError", "ModuleNotFoundError"
-   - "SyntaxError", "ImportError"
-3. **Extract context** around each error (file path, line number, error message)
-4. **Categorize** based on patterns above
-5. **Prioritize** by severity:
-   - High: Blocking issues (syntax errors, import errors, test failures)
-   - Medium: Type errors, assertion failures
-   - Low: Formatting, unused imports
-6. **Generate suggestions** for each error
-7. **Return structured output** in JSON format
+Read every log file in the input list. Grep is the right tool for finding error markers quickly in long logs — useful anchors include `FAILED`, `ERROR`, `error:`, `Error:`, `Would reformat`, `imported but unused`, `AssertionError`, `ModuleNotFoundError`, `SyntaxError`, `ImportError`. Extend this list when logs reveal new markers for tooling not yet covered.
+
+For every error found, pull the surrounding context (file path, line, message), match against the pattern library above, and include enough `raw` text that a human reader can cross-check your categorization. Skip warnings unless the caller asked for them — warnings aren't actionable in this pipeline.
+
+Group similar errors (multiple formatting issues in one file, multiple unused imports in one module) so downstream fixers can batch the reads. When one error cascades into others (a missing import causes 10 test failures), flag the root and mark the downstream as caused-by — fixing the root usually resolves all of them.
 
 ## Severity Guidelines
 
@@ -160,21 +153,9 @@ src/app.ts:25:10 - error TS2304: Cannot find name 'Foo'.
 - **Medium**: Code runs but may have issues (type errors, non-critical test failures)
 - **Low**: Code quality issues (formatting, unused variables)
 
-## Important Notes
+## Edge cases
 
-- Focus on **actionable errors** that can be automatically fixed
-- Skip warnings unless explicitly asked to include them
-- Group similar errors (e.g., multiple formatting issues in same file)
-- Extract exact file paths and line numbers when available
-- Include enough context in "raw" field for debugging
-- If logs are very large, use Grep to efficiently find error sections
-
-## Edge Cases
-
-- **Log truncation**: Note if logs appear truncated
-- **Multiple error types**: Categorize each separately
-- **Cascading errors**: Identify root cause vs. symptoms
-- **Flaky tests**: Note if test failures seem intermittent
-- **Third-party errors**: Flag errors from dependencies
-
-Remember: Your output directly feeds into the ci-error-fixer agent, so be precise and structured!
+- **Log truncation.** Note it explicitly in the output — a truncated log means errors are probably missing.
+- **Cascading errors.** Surface the root cause and mark downstream symptoms as caused-by. Otherwise `ci-error-fixer` tries to fix 10 identical "module not found" errors instead of the one import that caused them.
+- **Flaky tests.** If a test fails only intermittently (repeated runs with different outcomes), flag it — fixing code to make a flaky test pass is the wrong move.
+- **Third-party errors.** Dependency resolution issues, version mismatches from upstream — mark these separately; they usually need `uv pip install` or `bun install`, not code changes.

--- a/commands/address-pr-comments.md
+++ b/commands/address-pr-comments.md
@@ -2,683 +2,291 @@
 description: Interactive or autonomous PR comment resolution with mandatory replies
 ---
 
-# Address PR Comments Command
+# Address PR Comments
 
-Comprehensive PR comment resolution workflow that addresses reviewer feedback and posts replies to GitHub for every comment.
+## Role
 
-User provided: `$ARGUMENTS`
+Fetch every comment on a pull request, decide what to do with each one, apply fixes where it's safe to, and post a reply to every comment — no reviewer feedback leaves unanswered. Works in two modes: interactive (you approve each action before it runs) and autonomous (safe auto-fixes run unattended in CI).
 
-## Workflow Overview
+## Priorities
 
-This command fetches all PR comments, processes them according to mode (interactive/autonomous), applies fixes where possible, and **posts a reply to GitHub for every comment** — ensuring no feedback is left unacknowledged.
+Reviewer acknowledgment (every comment replied) > Fix safety (low-risk auto-fixes only) > Throughput
 
-## Phase 1: Preflight Checks and Comment Fetching
+## Invariants
 
-### 1.1 Preflight Checks
+These hold regardless of mode — they're the properties that make this command trustworthy:
 
-Before any processing, verify the environment is ready. These checks prevent partial failures mid-processing (e.g., committing without git identity, posting replies without auth, or accidentally staging uncommitted work alongside PR fixes).
+- **Every filtered comment receives one reply.** A fix without a reply is invisible to the reviewer; a reply without a fix at least closes the loop. Never skip the reply.
+- **Idempotent reruns.** If the current user has already replied to a comment, skip it — duplicate replies confuse the thread.
+- **One fix, one commit.** Stage only the files the fix touches (`git add {path}`), never `git add .` or `-A`. A bulk commit loses the audit trail and risks sweeping in unrelated uncommitted work.
+- **Posted replies are permanent.** Commits can be reverted; GitHub replies cannot. Surface this in the summary for autonomous runs so the user knows what's reversible.
+- **Reply body construction uses `jq --arg` piped to `gh api --input -`.** This prevents shell injection and JSON malformation from comment bodies containing `"`, `$`, or backticks. See **Reply posting** below.
 
-1. **`gh auth status`** — The command posts replies to GitHub. Without authentication, it would process comments and apply fixes but fail silently when posting. Abort early with "Not authenticated. Run: gh auth login"
-2. **`git status --porcelain`** — The command creates per-fix commits. If the working tree is dirty, those unrelated changes could get accidentally staged alongside PR fixes. Abort with "Working tree has uncommitted changes. Stash or commit changes first."
-3. **`git config user.name` and `git config user.email`** — Required for creating commits. Without these, git will either fail or create commits with no author. Abort with instructions to configure.
+## Preflight
 
-Fail fast on any of these — proceeding would cause confusing partial failures later.
+Run these checks before fetching anything — failing partway through is worse than failing immediately. Each guards against a specific failure class:
 
-### 1.2 Extract PR Information
+- `gh auth status` — without auth, the command would fetch, process, and fix, then fail silently when posting. Abort with `"Not authenticated. Run: gh auth login"`.
+- `git status --porcelain` — if the working tree has uncommitted changes, per-fix commits risk staging them alongside the fix. Abort with `"Working tree has uncommitted changes. Stash or commit first."`.
+- `git config user.name` / `user.email` — required for commits. Abort with configuration instructions.
 
-Parse `$ARGUMENTS` to extract PR number and determine repository context:
+Parse `$ARGUMENTS` for the PR. Accept a PR number (`123`), a full URL (`https://github.com/owner/repo/pull/123`), or extract from context. If no PR identifier resolves, abort with `"PR number or URL required"`.
 
-- If argument is a number (e.g., "123"): Use as PR number
-- If argument is a GitHub URL (e.g., "https://github.com/owner/repo/pull/123"): Extract PR number
-- If no argument: Abort with error "PR number or URL required"
+## Fetch and normalize
 
-Determine repository owner and name from current directory or URL.
-
-### 1.3 Fetch All Comment Types
-
-Fetch all three types of PR comments using GitHub API with pagination:
+Pull all three comment surfaces with pagination:
 
 ```bash
-# Get current authenticated user (for reply deduplication)
 CURRENT_USER=$(gh api user --jq '.login')
-
-# 1. Review comments (file/line-specific comments)
-gh api --paginate repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments > review_comments.json
-
-# 2. Review summaries (top-level review comments)
-gh api --paginate repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/reviews > review_summaries.json
-
-# 3. Issue comments (general PR discussion)
+gh api --paginate repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments  > review_comments.json
+gh api --paginate repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/reviews   > review_summaries.json
 gh api --paginate repos/{OWNER}/{REPO}/issues/{PR_NUMBER}/comments > issue_comments.json
 ```
 
-### 1.4 Normalize Comment Structure
-
-Parse and normalize all three types into a unified structure. Each comment should have:
+Normalize every comment into a unified shape — downstream logic shouldn't care which surface it came from:
 
 ```javascript
 {
-  id: number,                    // Comment ID for reply targeting
-  type: string,                  // "review" | "review-summary" | "issue"
-  path: string | null,           // File path (review comments only)
-  line: number | null,           // Line number (review comments only)
-  diff_hunk: string | null,      // Diff context (review comments only)
-  body: string,                  // Comment text
-  user: string,                  // Username of commenter
-  created_at: string,            // Timestamp
-  in_reply_to_id: number | null, // Parent comment ID (null if top-level)
-  review_state: string | null    // Review state for summaries (APPROVED, CHANGES_REQUESTED, etc.)
+  id: number,
+  type: "review" | "review-summary" | "issue",
+  path: string | null,
+  line: number | null,
+  diff_hunk: string | null,
+  body: string,
+  user: string,
+  created_at: string,
+  in_reply_to_id: number | null,
+  review_state: string | null  // summaries only: APPROVED, CHANGES_REQUESTED, etc.
 }
 ```
 
-**Type-specific normalization:**
+## Filter and check for prior replies
 
-1. **Review comments** (`type: "review"`):
-   - Extract from `review_comments.json`
-   - Has `path`, `line`, `diff_hunk`
-   - May have `in_reply_to_id`
+Exclude:
+- Comments already in a reply thread (`in_reply_to_id != null`) — those are conversation, not new feedback.
+- Comments from the PR author themselves.
+- Bot comments (user contains `bot` or `[bot]`).
+- Empty or whitespace-only bodies.
 
-2. **Review summaries** (`type: "review-summary"`):
-   - Extract from `review_summaries.json`
-   - No file/line context
-   - Has `state` field (APPROVED, CHANGES_REQUESTED, COMMENTED, etc.)
-   - `body` may be empty/null
+Keep everything else — questions, suggestions, praise, out-of-scope requests. All of them get processed because the goal is "no feedback unacknowledged."
 
-3. **Issue comments** (`type: "issue"`):
-   - Extract from `issue_comments.json`
-   - No file/line context
-   - General discussion
+For every kept comment, check if the current user already replied. For review comments, walk the reply thread by `in_reply_to_id`. For issue comments and review summaries, scan later issue comments from `CURRENT_USER` that reference the original. Mark `already_replied: true` on matches — these get shown in the summary but skip the reply step. Idempotency matters because this command is often re-run in CI.
 
-### 1.5 Filter Comments
+## Confidence scoring
 
-Apply filtering rules to determine which comments require processing:
+Score each comment 0–100 by how confident you are that the right fix is unambiguous. Autonomous mode uses this to decide what to auto-fix; interactive mode uses it to sort.
 
-**EXCLUDE:**
-- Comments where `in_reply_to_id != null` (already a reply in a thread)
-- Comments where `user` matches PR author's username
-- Comments from bots (user contains "bot" or "[bot]")
-- Comments with empty/whitespace-only `body`
+Judge holistically across these dimensions, not arithmetically:
 
-**INCLUDE:**
-- All other comments from review comments, review summaries, and issue comments
-- Questions, suggestions, praise, requests — everything gets processed
+- **Specificity.** A comment with `path`, `line`, a code suggestion, and a clear directive scores high. `"consider refactoring"` with no code scores low.
+- **Clarity.** Directive language (`"please change X to Y"`) is clearer than hedged (`"maybe consider"`). Questions without suggested changes score lowest.
+- **Risk.** Naming, formatting, comment edits are low-risk. Logic changes, API contract edits, test assertion changes can shift behavior — lower the confidence unless the suggestion is extremely specific.
+- **Authority.** Maintainer/owner comments carry more weight than outside contributors who may misunderstand the design. Not a hard rule; use judgment.
+- **Urgency.** `CHANGES_REQUESTED` reviews block merge. Treat them as higher priority than casual `COMMENTED` reviews.
 
-**DO NOT filter out:**
-- Questions (they need answers)
-- Praise (they deserve acknowledgment)
-- Out-of-scope comments (they need deferral responses)
+Thresholds for autonomous mode:
+- **≥ 80** — safe to auto-fix. Clear, specific, low-risk.
+- **60–79** — reply with clarification request. Ambiguous enough that guessing costs more than asking.
+- **< 60** — reply acknowledging, but don't act.
 
-### 1.6 Check for Existing Replies (Idempotency)
+These are defaults. A maintainer's `"please rename this variable"` might score 95; a vague contributor comment might score 30 — the score is a summary of judgment, not a formula.
 
-For each comment that passed filtering, check if the current user has already replied:
+## Mode detection
 
-```bash
-# For review comments (type: "review")
-# Check if any reply in the comment thread is from CURRENT_USER
-gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments/{COMMENT_ID} --jq '.user.login'
-# Also check the thread by looking at all comments and filtering by in_reply_to_id
+Auto-detect the mode; explicit flags win:
 
-# For issue comments (type: "issue")
-# Check if any subsequent issue comment quotes/references this one from CURRENT_USER
+- `--autonomous` / `--auto` / `auto` in arguments → autonomous.
+- `--interactive` / `interactive` in arguments → interactive.
+- `$CI`, `$GITHUB_ACTIONS`, `$JENKINS_URL`, `$GITLAB_CI`, `$CIRCLECI`, `$TRAVIS` set → autonomous.
+- Non-TTY stdin (`! [ -t 0 ]`) → autonomous.
+- Default → interactive.
 
-# For review summaries (type: "review-summary")
-# Check if any issue comment from CURRENT_USER references the review ID
-```
-
-**Mark as `already_replied: true`** if an existing reply from current user is found. These comments will be skipped from reply posting but shown in the summary.
-
-### 1.7 Confidence Scoring
-
-Score each comment 0-100 based on how confidently you can apply the right fix without human judgment. This score drives autonomous mode filtering and prioritization in interactive mode.
-
-**Judgment dimensions:**
-
-- **Specificity**: Does the comment point to exact code and suggest a concrete change? A comment saying "use const instead of let on line 42" is near-certain; "consider refactoring" is not. Comments with `path`, `line`, and code examples score highest.
-- **Clarity**: Is the intent unambiguous? Directive language ("please change", "must fix") is clearer than hedged language ("maybe consider", "could perhaps"). Questions without suggested changes score lowest.
-- **Risk**: Is the fix low-risk (naming, formatting, documentation) or could it change behavior (logic, API contracts, test assertions)? Low-risk changes can be applied with higher confidence.
-- **Authority**: Is the reviewer a maintainer with project context (`OWNER`, `COLLABORATOR`), or an outside contributor who may misunderstand the design? Maintainer feedback carries more weight.
-- **Urgency**: Is this from a `CHANGES_REQUESTED` review (blocking merge) or a casual `COMMENTED` review? Blocking reviews deserve higher priority.
-
-**Thresholds:**
-
-- **80+**: Safe to auto-fix in autonomous mode — clear, specific, low-risk
-- **60-79**: Present to user in interactive mode — reasonable but needs human judgment
-- **Below 60**: Reply without fixing — too ambiguous to act on confidently
-
-Use your judgment. These dimensions are guidelines for holistic assessment, not arithmetic. A comment from a maintainer saying "please rename this variable" might score 95; a vague comment from a contributor saying "this could be better" might score 30.
-
-Store the score with each comment for filtering and reporting.
-
-## Phase 2: Per-Comment Processing with Mandatory Replies
-
-### 2.1 Detect Execution Mode
-
-Auto-detect whether to run in interactive or autonomous mode:
-
-```bash
-# Check for explicit mode override in arguments
-if [[ "$ARGUMENTS" =~ (--autonomous|--auto|auto) ]]; then
-  MODE="autonomous"
-elif [[ "$ARGUMENTS" =~ (--interactive|interactive) ]]; then
-  MODE="interactive"
-# Check for CI/CD environment
-elif [[ -n "$CI" || -n "$GITHUB_ACTIONS" || -n "$JENKINS_URL" || -n "$GITLAB_CI" || -n "$CIRCLECI" || -n "$TRAVIS" ]]; then
-  MODE="autonomous"
-# Check if stdin is a TTY
-elif [[ ! -t 0 ]]; then
-  MODE="autonomous"
-else
-  MODE="interactive"
-fi
-```
-
-### 2.2 Create Safety Checkpoint (Autonomous Mode Only)
-
-**Before making any changes in autonomous mode**, create a rollback point:
+Autonomous mode before any edits, create a rollback checkpoint:
 
 ```bash
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 STASH_NAME="pre-autonomous-pr-${PR_NUMBER}-${TIMESTAMP}"
-
-# Stash any uncommitted changes
-if [ -n "$(git status --porcelain)" ]; then
-  git stash push -u -m "$STASH_NAME"
-  echo "✓ Uncommitted changes stashed as: $STASH_NAME"
-fi
-
-# Record current commit for reference
+[ -n "$(git status --porcelain)" ] && git stash push -u -m "$STASH_NAME"
 ROLLBACK_SHA=$(git rev-parse HEAD)
-echo "✓ Safety checkpoint created at commit: $ROLLBACK_SHA"
 ```
 
-### 2.3 Present Comments (Interactive Mode)
+Include both `$STASH_NAME` and `$ROLLBACK_SHA` in the final summary so rollback is a copy-paste.
 
-**IF MODE = "interactive":**
+## Present comments (interactive mode)
 
-Display all comments (regardless of confidence score) in organized format:
+Show every non-already-replied comment with its confidence score, sorted by priority. Use `AskUserQuestion` for selection (`"1,3,4"`, `"1-5"`, `"all"`, `"none"`). Display format:
 
 ```
 Found {N} comments on PR #{NUMBER}: {TITLE}
 
-Comments to Review:
-─────────────────────────────────────────────────────────
+1. [CODE] src/auth.ts:120 (Score: 90) — @owner
+   "Add null check before accessing user.email"
+   Suggested action: Add safety check
 
-1. [CODE] {file_path}:{line} (Score: 85) — @{reviewer}
-   "{comment body excerpt}"
-   Suggested action: {what needs to be done}
+2. [QUESTION] src/api.ts:55 (Score: 40) — @contributor
+   "Is this the right approach?"
+   Suggested action: Answer the question inline
 
-2. [STYLE] {file_path}:{line} (Score: 95) — @{reviewer}
-   "{comment body excerpt}"
-   Suggested action: {what needs to be done}
-
-3. [QUESTION] {file_path}:{line} (Score: 40) — @{reviewer}
-   "{comment body excerpt}"
-   Suggested action: Provide explanation
-
-4. [DOCS] No file specified (Score: 60) — @{reviewer}
-   "{comment body excerpt}"
-   Suggested action: Update documentation
-
-─────────────────────────────────────────────────────────
+[... etc]
 
 Which items would you like me to address?
-Options: "1,3,4" | "1-5" | "all" | "none"
 ```
 
-**Use AskUserQuestion tool** to get user selection.
+Only the user's selections get fixes. Everything else still gets a reply (deferral explanation) — the invariant holds.
 
-Parse user response and mark selected comments for processing.
+## Filter comments (autonomous mode)
 
-### 2.4 Filter Comments (Autonomous Mode)
+Display what will happen so the run is auditable. Items at ≥ 80 get fixes + replies; items below get replies only with honest reasons for not auto-fixing (e.g., `"suggestion lacks concrete implementation details"`, not a generic apology).
 
-**IF MODE = "autonomous":**
+## Per-comment processing
 
-Filter comments by confidence threshold (≥80) and display processing plan:
+Categorize each selected comment, then handle by category. Each category's reply reflects the actual action taken, not boilerplate:
 
-```
-🤖 AUTONOMOUS MODE ACTIVE
+### `actionable/clear` (score ≥ 80, has file and line)
 
-Analyzing {N} total comments on PR #{NUMBER}: {TITLE}
-Confidence threshold: 80/100
+Apply the fix, commit atomically, reply with the commit SHA.
 
-High-Confidence Items (will be addressed):
-─────────────────────────────────────────────────────────
+- **Locate code by context, not line number.** Use the `diff_hunk` as an anchor — line numbers drift as the PR accumulates fixes from this same command. If the surrounding context can't be found in the file, treat as `missing-file` rather than guessing.
+- **Verify before committing.** After the edit, `git diff --quiet -- "{path}"` tells you whether anything actually changed. If not, the code already matches the suggestion — reply accordingly instead of creating an empty commit.
+- **One commit per fix.**
+  ```bash
+  git add {path}
+  git commit -m "fix: {brief description}
 
-1. [STYLE] src/utils.ts:42 (Score: 95) — @maintainer
-   Comment: "Please use const instead of let for maxRetries"
-   Action: Change variable declaration → will fix + reply
+  Addresses comment from @{reviewer}
+  Comment ID: {id}"
+  ```
+- Capture the short SHA (`git rev-parse --short HEAD`) and include it in the reply. The reviewer should be able to click through to see exactly what changed.
 
-2. [CODE] src/auth.ts:120 (Score: 90) — @owner
-   Comment: "Add null check before accessing user.email"
-   Action: Add safety check → will fix + reply
+If the fix requires edits across multiple files or has behavioral implications you can't verify, reclassify as `actionable/unclear` and ask instead of guessing.
 
-Below-Threshold Items (will reply without fix):
-─────────────────────────────────────────────────────────
+### `actionable/unclear` (score 60–79, or suggestion ambiguous)
 
-3. [CODE] src/api.ts:55 (Score: 65) — @contributor
-   Comment: "Consider refactoring this for better performance"
-   Action: Reply requesting clarification
+Reply with specific interpretations of what the reviewer might mean — `"I see two readings of this: (a) … (b) … — which did you mean?"`. Shows you read the comment and narrows the discussion. No commit.
 
-4. [QUESTION] src/models.ts:78 (Score: 35) — @contributor
-   Comment: "This approach might have issues"
-   Action: Reply requesting specific concerns
+### `not-actionable/question`
 
-─────────────────────────────────────────────────────────
+Read the relevant code (if the comment has a `path`) and answer the actual question with context. Explain *why* the code is the way it is, based on what's actually there. If you don't know, say so and suggest who would. No commit.
 
-Processing {X} high-confidence items + replying to all {N} comments...
-```
+### `not-actionable/praise`
 
-### 2.5 Process Each Comment
+Brief acknowledgment. Match the reviewer's energy — a casual `"LGTM"` deserves a casual `"thanks"`, not a paragraph. No commit.
 
-For each comment (whether selected in interactive mode or high-confidence in autonomous mode), follow this workflow:
+### `not-actionable/out-of-scope`
 
-#### Category: `actionable/clear` (Score ≥ 80, has file+line)
+Acknowledge the value of the suggestion and explain the deferral. If you can point to a follow-up (future PR, separate issue), do so. Don't dismiss. No commit.
 
-**Goal:** Apply the reviewer's suggestion correctly, commit it atomically, and reply with the commit SHA.
+### `below-threshold` (autonomous mode only, score < 80)
 
-**Key principles:**
+Be honest about why you didn't auto-fix: `"suggestion lacks concrete implementation details"`, `"change could affect behavior in ways I can't verify"`. The reviewer should understand what action they can take next. No commit.
 
-- **Locate code by context, not line numbers.** The `diff_hunk` from the comment shows surrounding code context. Use this to find the right location because line numbers may have shifted from earlier fixes on the same file. If the context can't be found, treat as `missing-file`.
-- **One commit per fix** so each fix is traceable and independently revertable. Stage only the file you changed (`git add {path}` — never `git add .` or `git add -A`, because that risks staging unrelated changes).
-- **Verify before committing.** Check `git diff --quiet -- "{path}"` after applying the edit. If the file didn't actually change, the code already matches the suggestion — reply accordingly instead of creating an empty commit.
-- **If the file is missing or renamed**, don't guess — categorize as `missing-file` and reply asking the reviewer to confirm relevance.
+### `missing-file`
 
-**Commit message format:** `fix: {description}` with body referencing reviewer and comment ID, because this creates an audit trail linking commits to specific review feedback:
-```
-fix: {brief description}
+File referenced in the comment doesn't exist (or the `diff_hunk` context isn't found). Reply noting it may have been moved or renamed and ask the reviewer to confirm relevance. No commit.
 
-Addresses comment from @{reviewer}
-Comment ID: {id}
-```
+### Interactive mode: not selected
 
-Capture the commit SHA via `git rev-parse --short HEAD` and include it in the reply so the reviewer can click through to see exactly what changed.
+Reply noting the comment has been deferred to manual review. No commit.
 
-Use your judgment on fix complexity. If the suggestion requires changes across multiple files or has behavioral implications you're unsure about, categorize as `actionable/unclear` and ask for clarification instead of guessing.
+## Reply quality
 
-#### Category: `actionable/unclear` (Score 60-79, or unclear suggestion)
+Every reply should feel contextual, not like a bot processed it:
 
-Reply asking for clarification. Show the reviewer you understood their comment by offering specific interpretations of what they might mean, rather than a generic "please clarify." This narrows the discussion and helps them respond quickly.
+- Actionable fixes reference the specific commit SHA and briefly describe what changed.
+- Clarification requests offer specific interpretations rather than generic `"please clarify"`.
+- Question answers use code context — don't dodge with `"great question!"`.
+- Praise gets one sentence.
+- Deferrals explain *why* not just *that*.
 
-No commit — just reply.
+Match the reviewer's tone and formality.
 
-#### Category: `not-actionable/question`
+## Reply posting
 
-Read the relevant code (if the comment has a `path`, read that file for context) and answer the actual question. Explain *why* the code is written that way based on what you see. If you don't know, say so honestly and suggest who might.
-
-No commit — just reply.
-
-#### Category: `not-actionable/praise`
-
-Brief acknowledgment. Don't over-elaborate — match the reviewer's energy.
-
-No commit — just reply.
-
-#### Category: `not-actionable/out-of-scope`
-
-Acknowledge the value of the suggestion and explain why it's being deferred, not dismissed. If you can identify a follow-up context (future PR, separate issue), mention it.
-
-No commit — just reply.
-
-#### Category: `below-threshold` (Autonomous mode only, Score < 80)
-
-Be honest about why you didn't auto-fix. Explain the specific reason the confidence was low (e.g., "suggestion lacks concrete implementation details" or "change could affect behavior in ways I can't verify"). The reviewer should understand what to do next.
-
-No commit — just reply.
-
-#### Category: `missing-file`
-
-The file referenced in the comment doesn't exist. Reply noting it may have been moved or renamed, and ask the reviewer to confirm if the comment is still relevant.
-
-No commit — just reply.
-
-#### Interactive Mode: User Did Not Select
-
-For comments the user chose not to address, reply noting the comment has been deferred to manual review.
-
-No commit — just reply.
-
-### Reply Quality Criteria
-
-Every reply should be **contextual and useful** — not generic boilerplate. The reviewer should feel their specific feedback was understood, not that a bot processed it.
-
-**Judgment criteria:**
-- **Actionable fixes**: Reference the specific commit SHA. Briefly describe what changed so the reviewer doesn't have to click through.
-- **Clarification requests**: Offer specific interpretations rather than "please clarify." Show you read the comment.
-- **Questions**: Answer the actual question with code context. Don't dodge with "great question!"
-- **Praise/acknowledgment**: Brief and genuine. One sentence is fine.
-- **Deferrals**: Explain *why* it's deferred, not just *that* it's deferred.
-
-Adapt tone to the reviewer's tone. Match their formality level. A casual "LGTM" deserves a casual acknowledgment, not a formal response.
-
-### 2.6 Skip Already-Replied Comments
-
-If `already_replied: true` (detected in Phase 1.6), skip reply posting but include in summary report.
-
-## Phase 3: Reply Posting Logic
-
-### 3.1 Safe Reply Body Construction
-
-**CRITICAL: Prevent shell injection and malformed JSON.**
-
-Always construct reply bodies using `jq` with `--arg` flag and pipe to `gh api --input -`:
+**Security invariant: always construct reply bodies via `jq --arg` piped to `gh api --input -`.** Direct interpolation into `-f body="..."` breaks on comment bodies containing `"`, `$`, backticks, or newlines — worse, it's a shell-injection vector when the body is untrusted. This applies across every reply surface below.
 
 ```bash
-# CORRECT METHOD (prevents injection):
-jq -n --arg body "$REPLY_TEXT" '{body: $body}' | \
-  gh api -X POST "repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies" --input -
+# correct — injection-safe
+jq -n --arg body "$REPLY" '{body: $body}' | gh api -X POST "$ENDPOINT" --input -
 
-# NEVER USE THIS (unsafe):
-gh api -X POST "..." -f body="$REPLY_TEXT"
+# wrong — unsafe
+gh api -X POST "$ENDPOINT" -f body="$REPLY"
 ```
 
-### 3.2 Reply to Review Comments (type: "review")
+Endpoints vary by comment type:
 
-For comments with `type: "review"`:
+- **Review comments** (`type: "review"`) — reply directly in the thread:
+  ```bash
+  ENDPOINT="repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies"
+  ```
+- **Issue comments** (`type: "issue"`) — no reply threading, so quote the original (truncate bodies >200 chars to `...`) and post as a new issue comment:
+  ```
+  > {truncated original}
 
-```bash
-ENDPOINT="repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies"
+  {your reply}
+  ```
+  ```bash
+  ENDPOINT="repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments"
+  ```
+- **Review summaries** (`type: "review-summary"`) — no thread either. Quote the reviewer + review state, then post as an issue comment. If the original body is null (common for `APPROVED` reviews with no text), use `"No summary text provided — addressing based on review state ({state})."`.
 
-jq -n --arg body "$REPLY" '{body: $body}' | \
-  gh api -X POST "$ENDPOINT" --input -
-```
+### Retry on rate limit
 
-### 3.3 Reply to Issue Comments (type: "issue")
-
-For comments with `type: "issue"`:
-
-1. **Format reply with quote** (truncate original to 200 chars):
-   ```bash
-   QUOTED_ORIGINAL=$(echo "$ORIGINAL_BODY" | head -c 200)
-   if [ ${#ORIGINAL_BODY} -gt 200 ]; then
-     QUOTED_ORIGINAL="${QUOTED_ORIGINAL}..."
-   fi
-
-   FORMATTED_REPLY=$(cat <<EOF
-   > ${QUOTED_ORIGINAL}
-
-   ${REPLY}
-   EOF
-   )
-   ```
-
-2. **Post as new issue comment**:
-   ```bash
-   ENDPOINT="repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments"
-
-   jq -n --arg body "$FORMATTED_REPLY" '{body: $body}' | \
-     gh api -X POST "$ENDPOINT" --input -
-   ```
-
-### 3.4 Reply to Review Summaries (type: "review-summary")
-
-For comments with `type: "review-summary"`:
-
-1. **Format reply referencing the review**:
-   ```bash
-   # Handle empty/null body
-   if [ -z "$ORIGINAL_BODY" ] || [ "$ORIGINAL_BODY" = "null" ]; then
-     QUOTED_TEXT="No summary text provided — addressing based on review state (${REVIEW_STATE})."
-   else
-     QUOTED_ORIGINAL=$(echo "$ORIGINAL_BODY" | head -c 200)
-     if [ ${#ORIGINAL_BODY} -gt 200 ]; then
-       QUOTED_ORIGINAL="${QUOTED_ORIGINAL}..."
-     fi
-     QUOTED_TEXT="$QUOTED_ORIGINAL"
-   fi
-
-   FORMATTED_REPLY=$(cat <<EOF
-   > From @${REVIEWER}'s review (${REVIEW_STATE}):
-   > ${QUOTED_TEXT}
-
-   ${REPLY}
-   EOF
-   )
-   ```
-
-2. **Post as issue comment** (review summaries don't have reply threads):
-   ```bash
-   ENDPOINT="repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments"
-
-   jq -n --arg body "$FORMATTED_REPLY" '{body: $body}' | \
-     gh api -X POST "$ENDPOINT" --input -
-   ```
-
-### 3.5 Error Handling for Reply Posting
-
-Handle API errors gracefully with retries:
+GitHub throttles aggressive reply posting. Handle 429 and 403-with-rate-limit by reading `Retry-After` and backing off exponentially (1s, 2s, 4s), cap at 3 attempts:
 
 ```bash
-# Retry logic with exponential backoff
-MAX_RETRIES=3
-RETRY_COUNT=0
-BACKOFF=1
-
+MAX_RETRIES=3; RETRY_COUNT=0; BACKOFF=1
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
   HTTP_CODE=$(jq -n --arg body "$REPLY" '{body: $body}' | \
     gh api -X POST "$ENDPOINT" --input - -i 2>&1 | grep "HTTP" | awk '{print $2}')
-
-  if [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "200" ]; then
-    echo "✓ Reply posted successfully"
-    break
-  elif [ "$HTTP_CODE" = "403" ] || [ "$HTTP_CODE" = "429" ]; then
-    # Rate limited or forbidden - check Retry-After header
-    RETRY_AFTER=$(gh api -i ... | grep -i "retry-after" | awk '{print $2}')
-    WAIT_TIME=${RETRY_AFTER:-$BACKOFF}
-    echo "⏳ Rate limited, waiting ${WAIT_TIME}s before retry..."
-    sleep $WAIT_TIME
-    BACKOFF=$((BACKOFF * 2))
-    RETRY_COUNT=$((RETRY_COUNT + 1))
+  if [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "200" ]; then break; fi
+  if [ "$HTTP_CODE" = "429" ] || [ "$HTTP_CODE" = "403" ]; then
+    sleep $BACKOFF; BACKOFF=$((BACKOFF * 2)); RETRY_COUNT=$((RETRY_COUNT + 1))
   else
-    echo "❌ Failed to post reply (HTTP $HTTP_CODE), skipping..."
-    break
+    echo "Failed to post reply (HTTP $HTTP_CODE) — skipping"; break
   fi
 done
-
-if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
-  echo "❌ Max retries reached, reply not posted"
-fi
 ```
 
-## Phase 4: Summary Report
+Post-failure: surface the failed comment in the summary so the user can reply manually — a silent drop violates the "every comment replied" invariant.
 
-**Goal:** Give the user a clear picture of what happened — what was fixed, what was replied to, and what needs their attention.
+## Summary report
 
-### What to Include
+Group by action class so the user can scan:
 
-- **Statistics**: Fixes applied, replies posted, items skipped (already replied)
-- **Per-comment detail**: For each comment, show the action taken and reply status
-- **Next steps**: What the user should do now (review changes, run tests, push)
-- **Rollback instructions** (autonomous mode): How to undo commits, with a note that GitHub replies cannot be rolled back
+1. **Comments fixed + replied** — code changed, committed, reply posted with SHA.
+2. **Comments replied without fix** — questions answered, praise acknowledged, clarifications requested, deferrals.
+3. **Already replied (skipped)** — idempotency caught these; no action taken.
 
-### How to Structure
+Under 10 comments, show each inline with its action and reply. 10+, summarize by category with counts and list individual fixed items.
 
-Separate comments into clear groups so the user can scan quickly:
-1. **Comments Fixed + Replied** — code was changed, committed, and reply posted with SHA
-2. **Comments Replied Without Fix** — questions answered, praise acknowledged, clarifications requested, or items deferred
-3. **Already Replied (skipped)** — idempotency caught these; no action taken
+Next steps for the user: review the diff, run tests, push. Skip `"post replies manually"` — they're already posted. For autonomous mode, include the rollback stash name and base SHA, and note explicitly: commits can be reverted, replies cannot.
 
-For autonomous mode, include the rollback stash name and base commit SHA.
+## Error responses
 
-### Formatting Guidance
+Phrase errors so the user knows what to do next:
 
-Adapt detail level to the volume of comments:
-- **Few comments (< 10)**: Show each comment inline with its action and reply
-- **Many comments (10+)**: Summarize by category with counts, list only the fixed items individually
-
-Next steps should omit "post replies manually" (replies are already posted). Focus on: review the diff, run tests, push.
-
-Note clearly that commits can be reverted but replies posted to GitHub are permanent.
-
-## Error Handling
-
-### PR Not Found
 ```
-❌ Error: PR #{NUMBER} not found in {OWNER}/{REPO}
-   Verify the PR number/URL and try again.
-   Tip: Use `gh pr list` to see available PRs
+PR not found         — Verify the PR number/URL; `gh pr list` to browse.
+Not authenticated    — Run: gh auth login
+Working tree dirty   — git stash (or commit) before addressing PR comments.
+Git user unset       — git config user.name / user.email with instructions.
+No comments found    — All reviewers satisfied or comments already addressed.
+All already replied  — Nothing to do.
+File not found       — Comment references a moved/renamed path; reply asks reviewer to confirm.
+Rate limited         — Waiting {N}s before retry ({X}/{MAX}).
+Reply post failed    — Comment shown in summary; reply manually.
 ```
 
-### Not Authenticated
-```
-❌ Error: Not authenticated with GitHub CLI
-   Run: gh auth login
-```
+## Usage
 
-### Working Tree Dirty
-```
-❌ Error: Working tree has uncommitted changes
-   Stash them first: git stash
-   Or commit them before addressing PR comments
-```
-
-### Git User Not Configured
-```
-❌ Error: Git user not configured
-   Run:
-     git config user.name 'Your Name'
-     git config user.email 'your@email.com'
-```
-
-### No Comments Found
-```
-✅ No comments found on PR #{NUMBER}
-   All reviewers are satisfied or comments have been addressed.
-```
-
-### All Comments Already Replied
-```
-✅ All comments on PR #{NUMBER} have already been replied to
-   Nothing to process.
-```
-
-### File Not Found
-```
-⚠️  Warning: Comment references {file_path} which doesn't exist
-    This comment may be outdated or refers to a renamed file.
-    Reply posted: "This file appears to have been moved or renamed..."
-```
-
-### API Rate Limit
-```
-⏳ Rate limited by GitHub API
-   Waiting {N} seconds before retry (attempt {X}/{MAX})...
-```
-
-### Reply Posting Failed
-```
-❌ Failed to post reply to comment {COMMENT_ID} (HTTP {CODE})
-   Comment will be shown in summary but reply not posted.
-   You may need to reply manually.
-```
-
-## Implementation Notes
-
-### Comment Fetching
-- Use `gh api --paginate` for all comment endpoints to handle repos with many comments
-- Normalize all three comment types into unified structure for consistent processing
-- Track `in_reply_to_id` to avoid processing existing replies
-
-### Line Drift Safety
-- **Always use `diff_hunk` context** for locating code, not just API `line` number
-- API line numbers can become stale if files change after review
-- Extract surrounding code from `diff_hunk` and use as anchor text for matching
-- If context not found, treat as missing/renamed file
-
-### Reply Deduplication (Idempotency)
-- Before processing, check if current user already replied to each comment
-- For review comments: check reply threads via `in_reply_to_id`
-- For issue/review-summary comments: scan issue comment history
-- Mark as `already_replied: true` and skip posting (but show in summary)
-
-### Commit Strategy
-- **Per-fix commits** (not batched): Each actionable comment gets its own commit
-- Commit message format: `fix: {description}\n\nAddresses comment from @{reviewer}\nComment ID: {id}`
-- Stage **only the specific file** changed: `git add {path}` (never `git add .`)
-- Capture commit SHA for reply: `git rev-parse --short HEAD`
-
-### Reply Safety
-- **Always use `jq -n --arg body "$REPLY" '{body: $body}' | gh api --input -`**
-- This prevents shell injection and handles special characters correctly
-- Never use `-f body="..."` with complex/untrusted text
-
-### Confidence Scoring
-- Used for autonomous mode filtering (≥80 = auto-address) and interactive mode prioritization
-- Holistic assessment across specificity, clarity, risk, authority, and urgency
-- Store with each comment for reporting; scoring is heuristic — use judgment for edge cases
-
-### Mode Detection
-- Explicit flags (`--autonomous`, `--interactive`) override auto-detection
-- CI/CD environments auto-select autonomous mode
-- Non-TTY stdin auto-selects autonomous mode
-- Default to interactive if no signals detected
-
-### Safety in Autonomous Mode
-- Create git stash before any changes for easy rollback
-- Only auto-fix high-confidence items (score ≥80)
-- **Never auto-commit in bulk or auto-push** — leave that to user
-- Provide clear rollback instructions in summary
-- Note that replies posted to GitHub cannot be rolled back
-
-## Usage Examples
-
-**Interactive mode (default in terminal):**
 ```bash
 /address-pr-comments 123
 /address-pr-comments https://github.com/owner/repo/pull/456
+/address-pr-comments 123 --autonomous         # force autonomous
+/address-pr-comments 123 --interactive        # force interactive
 ```
 
-**Autonomous mode (auto-detected in CI or forced):**
-```bash
-/address-pr-comments 123 --autonomous
-/address-pr-comments 123 auto
-
-# In GitHub Actions workflow:
-- name: Address PR Comments
-  run: claude /address-pr-comments ${{ github.event.pull_request.number }}
-  # Automatically runs in autonomous mode due to CI environment
+In GitHub Actions, CI env vars trigger autonomous automatically:
+```yaml
+- run: claude /address-pr-comments ${{ github.event.pull_request.number }}
 ```
-
-**Force interactive mode:**
-```bash
-/address-pr-comments 123 --interactive
-```
-
-## Design Philosophy
-
-### Every Comment Gets a Reply
-
-This command ensures **no reviewer feedback is left unacknowledged**. Every comment receives a reply posted to GitHub, whether it's:
-- A fix with commit SHA
-- A request for clarification
-- An acknowledgment of praise
-- A deferral to manual review
-
-This creates clear communication and prevents reviewers from wondering if their feedback was seen.
-
-### Line-Drift Resilience
-
-By using `diff_hunk` context for code location instead of relying solely on API `line` numbers, this command handles cases where files have changed since the review was posted.
-
-### Safe Autonomous Operation
-
-Autonomous mode is designed for CI/CD environments where no human is present to approve changes. It:
-- Only auto-fixes high-confidence, low-risk items (score ≥80)
-- Creates rollback checkpoints before changes
-- Posts replies even for items it doesn't fix
-- Provides detailed audit trail in summary report
-
-### Per-Fix Commits
-
-Each code fix gets its own commit with a descriptive message referencing the reviewer and comment ID. This makes it easy to:
-- Review changes individually
-- Cherry-pick or revert specific fixes
-- Track which commit addressed which comment
-- Generate meaningful git history
-
-### Idempotency
-
-Running the command multiple times is safe:
-- Already-replied comments are detected and skipped
-- No duplicate replies are posted
-- Existing commits are not re-created
-- Summary report clearly shows what was skipped vs. processed

--- a/commands/fix-ci.md
+++ b/commands/fix-ci.md
@@ -2,218 +2,135 @@
 description: Auto-detect, analyze, and fix CI/CD failures on any branch
 ---
 
-# Fix CI/CD Failures
+# Fix CI Failures
 
-Auto-detect, analyze, and fix CI/CD failures on any branch using GitHub CLI and specialized agents.
+## Role
+
+Find why CI is failing on a branch or PR and fix the underlying code so CI passes. Delegate log parsing to the `ci-log-analyzer` agent and fix application to the `ci-error-fixer` agent — trust their output rather than re-parsing logs in this command.
+
+## Priorities
+
+Root-cause fix (not a workaround) > Minimal blast radius (one commit per coherent fix) > Fast turnaround
+
+## Invariants
+
+- **Don't disable a test or lint rule to make CI green.** Those are signal. If a test fails, either the test is wrong (fix the test) or the code is wrong (fix the code). Suppressing the signal hides the bug.
+- **No `--no-verify` on commits.** Pre-commit hooks catch regressions locally before CI even runs; skipping them moves failures downstream.
+- **Branch protection holds.** Never run this workflow on `main` / `master` without explicit user approval. The safer path is a hotfix branch.
+- **Preserve uncommitted work.** If the tree is dirty, stash it before applying fixes, then restore.
 
 ## Usage
 
 ```bash
-/fix-ci              # Current branch (single fix)
-/fix-ci 123          # PR number (single fix)
-/fix-ci https://...  # PR URL (single fix)
-/fix-ci --loop       # Autonomous loop mode (up to 10 retries)
-/fix-ci --auto       # Alias for --loop
-/fix-ci 123 --loop   # Loop mode for specific PR
+/fix-ci              # current branch (single iteration)
+/fix-ci 123          # PR number
+/fix-ci https://...  # PR URL
+/fix-ci --loop       # autonomous loop (up to 10 retries), delegates to ci-fix-loop skill
+/fix-ci --auto       # alias for --loop
+/fix-ci 123 --loop   # loop mode targeting a specific PR
 ```
 
-User provided: `$ARGUMENTS`
+## Routing
 
-## Autonomous Loop Mode
+`--loop` or `--auto` in `$ARGUMENTS` → delegate to the `ci-fix-loop` skill. That skill owns the full autonomous cycle (analyze → fix → commit → push → wait on CI → repeat, up to 10 iterations), and handles background monitoring and per-iteration safety. This command should hand off cleanly — don't duplicate the loop logic here.
 
-When `--loop` or `--auto` flag is present, this command runs in autonomous mode using the `ci-fix-loop` skill.
-
-**Detection:**
 ```bash
 ARGS="$ARGUMENTS"
 if [[ "$ARGS" == *"--loop"* ]] || [[ "$ARGS" == *"--auto"* ]]; then
-  # Extract PR number if provided (e.g., "123 --loop" → "123")
   PR_NUM=$(echo "$ARGS" | grep -oE '^[0-9]+' || echo "")
-
-  # Invoke ci-fix-loop skill
-  # The skill will handle the full autonomous loop:
-  # 1. Analyze CI errors
-  # 2. Apply fixes
-  # 3. Commit and push
-  # 4. Monitor CI in background (polling every 60s)
-  # 5. If CI fails, repeat (up to 10 times)
-  # 6. Report final status
-
-  # IMPORTANT: Do not proceed with single-fix workflow below
+  # Invoke ci-fix-loop skill with $PR_NUM; return.
 fi
 ```
 
-**Behavior:**
-- Runs up to 10 fix-commit-push-wait cycles
-- Fully autonomous (no user prompts)
-- Background CI monitoring between iterations
-- Reports detailed history when complete
-- Aborts if same errors appear twice consecutively
+Without those flags, run the single-iteration workflow below.
 
-**Safety:**
-- Will not run on main/master branch
-- Stashes uncommitted changes before starting
-- Maximum 30 minute wait per CI run
+## Single-iteration workflow
 
----
+### Detect context
 
-When NOT in loop mode, proceed with single-fix workflow below.
-
-## Workflow
-
-### Step 1: Detect Context
-
-First, determine what CI context we're working with:
+Figure out what CI pipeline this branch or PR is actually using. The detection order prioritizes PRs because they carry richer metadata than raw workflow runs:
 
 ```bash
 CURRENT_BRANCH=$(git branch --show-current)
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 ```
 
-**Priority order:**
-1. If user provided PR number/URL: use that
-2. Feature branch with PR: use PR checks
-3. Feature branch without PR: use `gh run list`
-4. Main/master: use `gh run list`
+1. User passed a PR number or URL → use that directly.
+2. Feature branch with an open PR → use PR checks (`gh pr status`, `gh pr view {PR} --json statusCheckRollup`).
+3. Feature branch without a PR → fall back to recent workflow runs (`gh run list --branch`).
+4. `main` / `master` → prompt before doing anything (see invariants); if approved, use workflow runs.
 
-**Detection commands:**
+### Fetch the failed logs
 
-For **main/master branch**, use workflow runs:
+Once the context is resolved, pull logs for every failed job. Save to `/tmp/ci-logs-{JOB_ID}.txt` so the log-analyzer agent can read them from disk without re-fetching:
+
 ```bash
-gh run list --branch "$CURRENT_BRANCH" --limit 5 --json databaseId,status,conclusion,name
-```
-
-For **feature branches**, check for PR first:
-```bash
-gh pr status --json number,title,url,headRefName
-```
-
-If no PR exists on feature branch, fall back to runs:
-```bash
-gh run list --branch "$CURRENT_BRANCH" --limit 5 --json databaseId,status,conclusion,name
-```
-
-### Step 2: Fetch Failed CI Logs
-
-Once you've identified the context, fetch logs for failed checks.
-
-**PR-based approach:**
-```bash
-# Get failed checks from PR
+# PR path
 gh pr view {PR} --json statusCheckRollup | jq '.statusCheckRollup[] | select(.conclusion == "FAILURE")'
-
-# Fetch job logs
 gh api repos/${REPO}/actions/jobs/{JOB_ID}/logs > /tmp/ci-logs-{JOB_ID}.txt
-```
 
-**Run-based approach:**
-```bash
-# Get most recent failed run
+# Run path
 RUN_ID=$(gh run list --branch "$CURRENT_BRANCH" --limit 5 --json databaseId,conclusion --jq '[.[] | select(.conclusion == "failure")][0].databaseId')
-
-# Get failed jobs from run
 gh run view $RUN_ID --json jobs --jq '.jobs[] | select(.conclusion == "failure")'
-
-# Fetch job logs
 gh api repos/${REPO}/actions/jobs/{JOB_ID}/logs > /tmp/ci-logs-{JOB_ID}.txt
 ```
 
-### Step 3: Analyze Errors with CI Log Analyzer Agent
+### Find stage — parse errors via `ci-log-analyzer`
 
-Launch the `ci-log-analyzer` agent to parse the logs and identify error patterns:
+Launch the `ci-log-analyzer` agent with the log paths. The agent categorizes errors (lint / test / type / build), extracts file paths and line numbers, and returns a structured list. Trust that output — if the agent thinks an error is `type-error` at `src/x.ts:42`, don't re-read the logs to second-guess.
 
-```bash
-# Use Task tool to launch ci-log-analyzer agent
-```
+The agent covers common patterns: Ruff/Prettier/Biome format diffs, test failures (pytest `FAILED`, Jest `● FAIL`, Go `--- FAIL`), type errors (mypy, tsc, Flow), build errors (`SyntaxError`, `ImportError`, missing deps).
 
-The agent will identify:
-- **Ruff/Lint errors**: `Would reformat: {file}`, unused imports, etc.
-- **Test failures**: `FAILED tests/...`, `AssertionError`, `ModuleNotFoundError`
-- **Type errors**: `error: Incompatible types`, `Missing return statement`
-- **Build errors**: `SyntaxError`, `ImportError`, missing dependencies
+### Filter stage — decide what to fix this iteration
 
-Agent returns structured error list with:
-- Error type (lint/test/type/build)
-- Affected file paths
-- Error messages
-- Line numbers (if available)
+From the full error list, pick a coherent subset to address in a single commit. Rules of thumb:
 
-### Step 4: Apply Fixes with CI Error Fixer Agent
+- Fix every error in a single category before mixing (all lint first, then tests, then types) — one commit per category reads cleaner in git history.
+- If one error is a root cause for others (e.g., a missing import cascades into multiple test failures), fix the root and let the follow-ups resolve themselves.
+- If the error list has > 20 items across multiple categories, surface the plan to the user and ask which to prioritize rather than attempting everything at once.
 
-Launch the `ci-error-fixer` agent with the error list from Step 3:
+Out of this iteration's scope: flakes that weren't reproduced, infrastructure issues (GitHub Actions outages, runner pool), errors in paths the current branch didn't touch. Note these in the summary rather than silently ignoring.
 
-```bash
-# Use Task tool to launch ci-error-fixer agent with error context
-```
+### Apply fixes via `ci-error-fixer`
 
-The agent will:
-1. Read affected files
-2. Apply appropriate fixes based on error type:
-   - **Ruff**: Run `uv run ruff format {file}` or apply formatting
-   - **Tests**: Fix assertions, imports, test setup
-   - **Types**: Add type hints, fix type mismatches
-   - **Build**: Fix syntax, add missing imports
-3. Show diffs for each change
-4. Report completion status
+Launch the `ci-error-fixer` agent with the filtered error list. The agent reads the affected files, applies fixes appropriate to each error type, and reports diffs. Trust the agent's output — it's the specialist for this flow.
 
-### Step 5: Summary & Next Steps
-
-Present a summary of all fixes applied:
+### Summarize
 
 ```
-✅ Fixed {N} issues:
-  • Lint: {file1} - {description}
-  • Test: {file2} - {description}
-  • Type: {file3} - {description}
+Fixed {N} issues:
+  • Lint: {file1} — {what changed}
+  • Test: {file2} — {what changed}
+  • Type: {file3} — {what changed}
 
-Next steps:
-  1. Review changes: git diff
-  2. Commit: git add . && git commit -m "fix: CI failures"
+Out of scope this run:
+  • Flake at tests/x.spec.ts (not reproducible locally)
+
+Next:
+  1. Review: git diff
+  2. Commit: git add {files} && git commit -m "fix: CI {category}"
   3. Push: git push
 ```
 
-## Safety Checks
+Don't auto-commit or auto-push in single-iteration mode — the user needs to approve the diff first. Loop mode delegates that responsibility to the `ci-fix-loop` skill.
 
-**IMPORTANT: Run these checks before making any changes:**
+## Safety gates
 
-1. **Main/master branch warning:**
-   ```bash
-   if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
-     echo "⚠️  WARNING: You're on $CURRENT_BRANCH branch."
-     echo "Suggest creating hotfix branch: git checkout -b hotfix/ci-fixes"
-     # Ask user if they want to continue or create branch
-   fi
-   ```
+Apply before any fix lands:
 
-2. **Uncommitted changes:**
-   ```bash
-   if [[ -n $(git status -s) ]]; then
-     echo "⚠️  WARNING: You have uncommitted changes."
-     echo "Consider stashing: git stash"
-     # Ask user if they want to continue
-   fi
-   ```
+- **On `main` / `master`.** Prompt: `"You're on $CURRENT_BRANCH. Suggest hotfix branch: git checkout -b hotfix/ci-fixes"`. Ask before continuing — fixing CI on main directly is usually the wrong shape.
+- **Uncommitted changes.** Warn and offer to stash: `git stash push -u -m "pre-fix-ci"`. Restore after (regardless of success/failure).
+- **Ambiguous errors.** When the log-analyzer returns something that doesn't cleanly map to a fix strategy, flag it and ask the user. Guessing on an unfamiliar failure mode usually makes things worse.
 
-3. **Unclear fixes:**
-   - If error patterns are ambiguous or fixes are uncertain
-   - Flag for manual review
-   - Show the error and ask user how to proceed
+## Error responses
 
-4. **Multiple failures:**
-   - If there are many failures across different categories
-   - Ask user which to prioritize (lint/test/type/build)
-   - Or ask if they want to fix all
-
-## Error Handling
-
-If any step fails:
-- Show clear error message
-- Suggest manual investigation steps
-- Provide relevant gh CLI commands for debugging
+```
+Not authenticated       — Run: gh auth login
+No failed checks found  — CI is passing or hasn't run yet.
+Log fetch failed        — Suggest manual: gh run view $RUN_ID --log-failed
+Agent fix failed        — Show agent output; suggest manual investigation.
+```
 
 ## Notes
 
-- Requires `gh` CLI to be installed and authenticated
-- Uses specialized agents for complex parsing and fixing
-- Always shows diffs before finalizing
-- Never commits automatically without user confirmation
+Requires `gh` CLI authenticated (`gh auth status`). Delegates parsing and fixing to specialized agents — this command's job is context detection, log fetching, and coordination.

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -2,531 +2,282 @@
 description: Comprehensive Pull Request Review
 ---
 
-# Pull Request Review Command
+# Pull Request Review
 
-You are a comprehensive PR reviewer conducting a thorough analysis of a GitHub pull request. Your role is to understand the changes, context from discussions, and provide actionable feedback.
+## Role
 
-User provided: `$ARGUMENTS`
+Conduct a thorough review of a GitHub pull request: understand the intent, assess the diff against that intent, and surface issues the PR author and maintainer should know about. Output is an organized report, not a merge decision — leave the approve/request-changes call to humans.
 
-## CRITICAL: Route Selection
+## Priorities
 
-BEFORE taking any other action, check `$ARGUMENTS` for the `--swarm` flag:
+Finding coverage (everything worth surfacing gets surfaced) > Evidence (every finding cites `file:line`) > Actionability (fixes suggested, not just problems named) > Brevity
 
-1. If `--swarm` IS present: remove it from the arguments (the remaining text is the PR identifier — number, URL, or owner/repo#number format), then skip directly to **Swarm Workflow**. Do NOT execute any Standard Workflow steps.
-2. If `--swarm` is NOT present: the full `$ARGUMENTS` is the PR identifier, skip directly to **Standard Workflow**. Do NOT execute any Swarm Workflow steps.
+## Scope
+
+`$ARGUMENTS` is a PR identifier: a number (`123`), a URL (`https://github.com/owner/repo/pull/456`), or `owner/repo#number`.
+
+## Routing
+
+Standard flow is the default — one reviewer covers every concern sequentially. Pass `--swarm` for a team of four specialized reviewers (security, performance, tests, architecture) working in parallel; that's the right choice for large diffs (>30 files) or PRs where one dimension dominates (security-critical changes, perf-sensitive code paths). Strip `--swarm` from the args; the remainder is the PR identifier.
+
+If swarm mode is requested but `TeamCreate` isn't available:
+```
+Swarm mode requires agent teams. Set CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 in settings.json or environment.
+Falling back to standard workflow.
+```
+Then continue with the PR identifier already parsed.
+
+## PR context (both modes)
+
+Fetch everything the review will touch before doing any analysis — partial context produces partial findings:
+
+```bash
+# metadata
+gh pr view {PR_NUMBER} --json title,body,state,author,headRefName,baseRefName,url,commits,reviews,comments,labels,milestone
+
+# diff and discussion
+gh pr diff {PR_NUMBER}
+gh pr view {PR_NUMBER} --comments
+gh pr checks {PR_NUMBER}
+
+# local checkout for file reads
+gh pr checkout {PR_NUMBER}
+BASE_BRANCH=$(gh pr view {PR_NUMBER} --json baseRefName -q .baseRefName)
+```
+
+Before reviewing, read the project conventions — they shape what "reasonable" looks like in this codebase:
+- `CONTRIBUTING.md` — review guidelines.
+- `CLAUDE.md` — project-specific instructions.
+- `.github/PULL_REQUEST_TEMPLATE.md` — required PR content.
+- CI config — what's auto-checked vs what the review needs to catch.
 
 ---
 
-## Swarm Workflow
+## Standard workflow
 
-An alternative approach using agent teams for PR review that benefits from parallel specialized analysis. This works well for comprehensive reviews where different aspects (security, performance, testing, architecture) can be evaluated independently.
+### Analyze
 
-### Team Prerequisites and Fallback
+Compare against the base branch and walk every change:
 
-Attempt to create the agent team using `TeamCreate` with a unique timestamped name: `review-pr-{number}-{YYYYMMDD-HHMMSS}` and description: "PR Review: {title}".
-
-If team creation fails (tool unavailable or experimental features disabled), inform the user that swarm mode requires agent teams to be enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings.json), then fall back to executing the Standard Workflow instead. The PR identifier is already parsed and ready to use.
-
-### Phase 1: PR Information Gathering
-
-Execute the same PR information gathering steps as Standard Workflow Phase 1 (extract PR identifier, fetch metadata, checkout branch). This establishes the shared context that all teammates will need.
-
-After gathering PR information and checking out the branch, proceed to spawn teammates for parallel review.
-
-### Shared Task List
-
-Create tasks via `TaskCreate` that represent the specialized review areas:
-1. **Security Review** — Identify security vulnerabilities and risks
-2. **Performance Review** — Evaluate performance implications
-3. **Test Coverage Review** — Assess test adequacy and quality
-4. **Architecture Review** — Examine design patterns and code organization
-
-These tasks provide structure for parallel specialized reviews.
-
-### Teammate Roles and Spawn Protocol
-
-After completing Phase 1, spawn 4 specialized reviewer teammates via the `Task` tool with `team_name` parameter and `subagent_type: "general-purpose"`. Each teammate prompt MUST include as string literals (NOT references to conversation):
-
-**Required Context in Each Spawn Prompt**:
-- PR title
-- PR author
-- Base branch name
-- Head branch name
-- Diff summary from `git diff $BASE_BRANCH...HEAD --stat`
-- List of changed files
-- For PRs with ≤50 changed files: Include the changed file contents (read them before spawning)
-- For PRs with >50 changed files: Include file list only, instruct teammates to Read specific files they need to examine
-- PR description/body
-
-**Teammate 1: Security Reviewer**
-
+```bash
+git diff $BASE_BRANCH...HEAD --stat
+git diff $BASE_BRANCH...HEAD
+git log $BASE_BRANCH..HEAD --no-merges
 ```
-You are conducting a security-focused review as part of a PR review team.
 
-PR TITLE: {literal PR title}
-PR AUTHOR: {literal author}
-BASE BRANCH: {literal base branch}
-HEAD BRANCH: {literal head branch}
+For every changed file, understand the change on its own terms. New files — what's their purpose? Deleted files — why were they removed? Modified files — what semantic change was made? Test files — does the new code have test coverage commensurate with its risk? Documentation — did the docs that describe this code get updated too?
+
+Also fold in the discussion: unresolved review threads, CI status, linked issues. Context from a conversation often explains why a choice was made that looks wrong at the file level.
+
+### Find stage
+
+Collect every issue worth surfacing, no self-censoring. 4.7 will suppress "minor" findings if the prompt says "only surface important issues" — don't let it. For each finding, record:
+
+- **Severity**: `blocker` | `major` | `minor` | `nit`
+- **Confidence**: `high` | `medium` | `low`
+- **Location**: `file:line` (or `file` for global concerns)
+- **Category**: `correctness` / `security` / `performance` / `tests` / `docs` / `style` / `architecture`
+- **One-line reasoning** — what makes this a finding, not a preference
+
+Cover every axis. If you're only finding issues in one dimension, you're not looking hard enough at the others.
+
+Severity calibration (apply to every finding, not just the obvious ones):
+- **Blocker** — merge would introduce a correctness bug, security hole, or break a deployed contract.
+- **Major** — likely to cause noticeable problems in production or maintenance, but merge isn't unsafe.
+- **Minor** — smells, inconsistencies, or small cleanup opportunities; fine to defer.
+- **Nit** — style, wording, or personal preference with negligible impact.
+
+Confidence calibration:
+- **High** — you traced the issue through the code and can cite the exact mechanism.
+- **Medium** — the issue is probable based on pattern, but you didn't verify end-to-end.
+- **Low** — suspicious but you'd want someone to double-check.
+
+### Filter stage
+
+From the find-stage list, surface to the report:
+- Every `blocker` (any confidence).
+- Every `major` with confidence ≥ medium.
+- `minor` findings grouped as a single section, one line each.
+- `nit` findings as an optional trailing group, one line each.
+
+Drop low-confidence `major` or below unless two or more independently suggest the same area — in which case surface it and flag the uncertainty.
+
+### Report
+
+Structure the output for the PR author to act on, not just read. Use `file:line` everywhere a location exists.
+
+```markdown
+# PR Review: #{number} — {title}
+
+## Summary
+- **Purpose**: {one-line description of what the PR does}
+- **Scope**: {feature / bugfix / refactor / docs / chore / ...}
+- **Risk**: {low / medium / high — and why}
+- **Overall**: {thumbnail verdict — "looks solid", "ready pending fixes", "needs discussion", etc. — this is input to human reviewers, not a merge decision}
+
+## Findings
+
+### Blockers
+- **[correctness, high conf]** `src/auth.ts:42` — {description + execution path}. Fix: {suggested change}.
+
+### Major
+- **[security, medium conf]** `src/api/handler.ts:118–140` — {description}. Fix: {suggested change}.
+
+### Minor
+- `src/util.ts:8` — variable name suggests the wrong invariant.
+- `tests/form.spec.ts:55` — assertion relies on internal shape; could be brittle.
+
+### Nits
+- `README.md:L24` — typo "recieve".
+
+## Discussion & CI
+
+- Unresolved threads: {summary or "none"}
+- CI: {passing / N failing / pending}
+- Linked issues: {list}
+
+## Positive notes
+
+- {genuine praise for well-done parts — not boilerplate}
+
+## Suggested follow-up session
+
+Offer: deep-dive into a specific file, run tests, search for similar patterns elsewhere, or draft a GitHub review comment from the findings above.
+```
+
+---
+
+## Swarm workflow
+
+Parallelize by dimension when the PR is big or multi-faceted. Four specialized reviewers run concurrently, each covering one concern; findings get consolidated with the same find/filter discipline.
+
+### Team setup
+
+Create the team with `TeamCreate`: name `review-pr-{number}-{YYYYMMDD-HHMMSS}`, description `PR Review: {title}`. Register four shared tasks via `TaskCreate`: Security, Performance, Test Coverage, Architecture.
+
+### Context for teammates
+
+Teammates can't see this conversation. Every spawn prompt embeds literally:
+
+- PR title, author, base and head branches.
+- Diff summary: `git diff $BASE_BRANCH...HEAD --stat`.
+- Changed file list.
+- PR description/body.
+- For PRs ≤50 files: include the full changed file contents in the prompt. For PRs >50 files: include the file list only and tell the teammate to `Read` what they need.
+
+### Teammate dispatch
+
+Spawn all four via `Task` with `team_name` and `subagent_type: "general-purpose"`. The prompts share most of their structure; the specialization is in the role, judgment criteria, and cross-concern triggers:
+
+<example name="Specialized reviewer prompt template">
+You are conducting a {Security | Performance | Test Coverage | Architecture} review as part of a PR review team.
+
+PR TITLE: {literal}
+PR AUTHOR: {literal}
+BASE BRANCH: {literal}
+HEAD BRANCH: {literal}
 
 DIFF SUMMARY:
-{literal git diff --stat output}
+{literal stat output}
 
 CHANGED FILES:
-{literal list of changed files}
+{literal list}
 
-[If ≤50 files]
+{If ≤50 files:}
 CHANGED FILE CONTENTS:
-{literal file contents}
+{literal contents}
 
-[If >50 files]
-Note: This PR has >50 changed files. Use the Read tool to examine specific files you need to review for security concerns.
+{If >50 files:}
+Note: >50 changed files. Use `Read` to examine files relevant to your concern.
 
 PR DESCRIPTION:
-{literal PR body}
+{literal body}
 
-YOUR TASK:
-Review this PR for security vulnerabilities and risks. Apply your security expertise to identify issues that could expose the application to attacks or data breaches.
+YOUR ROLE — {role-specific sentence}:
+- Security: find vulnerabilities and risks an attacker could exploit or that expose data.
+- Performance: find changes that will degrade response times, increase resource use, or create scale bottlenecks.
+- Test Coverage: assess whether the suite adequately covers the changes and would catch regressions.
+- Architecture: evaluate design patterns, separation of concerns, and fit with codebase conventions.
 
-Judgment criteria for severity:
-- Critical: Directly exploitable vulnerability (e.g., unsanitized user input reaching a database query, exposed secrets)
-- High: Vulnerability requiring specific conditions to exploit (e.g., missing auth check on internal endpoint)
-- Medium: Weakness that increases attack surface (e.g., overly permissive CORS, verbose error messages)
-- Low: Best practice violation with minimal direct risk (e.g., missing security headers)
+SEVERITY — calibrate to your dimension:
+- Critical: {role-specific example — e.g., "unsanitized user input reaching a SQL query" / "N+1 in hot path" / "new API endpoint with no tests" / "breaking change to public API"}.
+- High: {role-specific example — e.g., "missing auth on internal endpoint" / "missing index on growing table" / "error paths untested" / "significant deviation from codebase conventions"}.
+- Medium: {role-specific example — e.g., "verbose error messages leaking internals" / "unnecessary allocations in loops" / "shallow tests that only cover happy path" / "logic in wrong layer"}.
+- Low: {role-specific example — best practice violations with minimal real impact}.
 
-Common areas to examine: authentication flows, input handling, dependency changes, secrets in code, and authorization boundaries. Use your expertise to identify issues beyond this list.
-
-CROSS-CONCERN FINDINGS:
-If you find security issues that also have performance implications (e.g., DoS potential), share via SendMessage:
-"Security: This {issue} at {file}:{line} also has {other concern} implications — {explanation}"
-
-WORKING CONSTRAINTS:
-You're operating in a parallel review team. This means:
-- Read-only access: Don't modify the codebase or run build/test commands — other reviewers are working concurrently and modifications would cause conflicts.
-- Team communication only: Use SendMessage for cross-concern findings. You cannot interact with the user directly.
-
-COMPLETION:
-When you've completed your security review, mark your task complete via TaskUpdate with your findings, send "REVIEW COMPLETE" via SendMessage, and wait for shutdown_request.
-
-FINDINGS GUIDANCE:
-For each issue, include file path with line numbers, severity level, vulnerability description, and remediation recommendation. Match detail level to severity — critical issues deserve thorough explanation.
-```
-
-**Teammate 2: Performance Reviewer**
-
-```
-You are conducting a performance-focused review as part of a PR review team.
-
-PR TITLE: {literal PR title}
-PR AUTHOR: {literal author}
-BASE BRANCH: {literal base branch}
-HEAD BRANCH: {literal head branch}
-
-DIFF SUMMARY:
-{literal git diff --stat output}
-
-CHANGED FILES:
-{literal list of changed files}
-
-[If ≤50 files]
-CHANGED FILE CONTENTS:
-{literal file contents}
-
-[If >50 files]
-Note: This PR has >50 changed files. Use the Read tool to examine specific files you need to review for performance concerns.
-
-PR DESCRIPTION:
-{literal PR body}
-
-YOUR TASK:
-Review this PR for performance implications. Identify changes that could degrade response times, increase resource consumption, or create scalability bottlenecks.
-
-Judgment criteria for impact:
-- Critical: Changes that will noticeably degrade performance at current scale (e.g., N+1 queries in a hot path, O(n²) on large datasets)
-- High: Changes likely to cause issues at moderate scale (e.g., missing index on a growing table, synchronous I/O in async context)
-- Medium: Suboptimal patterns that accumulate (e.g., unnecessary allocations in loops, missed caching opportunities)
-- Low: Minor inefficiencies with negligible real-world impact (e.g., slightly verbose serialization)
-
-Common areas to examine: algorithmic complexity, database query patterns, memory/resource management, async patterns, and bundle size. Use your expertise to identify issues beyond this list.
+Apply find/filter discipline: note *every* issue you see at every severity, then surface all high+critical and a representative sample of medium/low. 4.7 otherwise suppresses low-severity findings the team lead actually wants.
 
 CROSS-CONCERN FINDINGS:
-If you find performance issues that also have security implications (e.g., DoS potential), share via SendMessage:
-"Performance: This {issue} at {file}:{line} also has {other concern} implications — {explanation}"
+When a finding spans concerns (e.g., a security issue also has perf implications), share via `SendMessage`:
+"{Your role}: {issue} at {file}:{line} also has {other concern} implications — {explanation}"
 
-WORKING CONSTRAINTS:
-You're operating in a parallel review team. This means:
-- Read-only access: Don't modify the codebase or run build/test commands — other reviewers are working concurrently and modifications would cause conflicts.
-- Team communication only: Use SendMessage for cross-concern findings. You cannot interact with the user directly.
-
-COMPLETION:
-When you've completed your performance review, mark your task complete via TaskUpdate with your findings, send "REVIEW COMPLETE" via SendMessage, and wait for shutdown_request.
-
-FINDINGS GUIDANCE:
-For each issue, include file path with line numbers, impact level, concern description, and optimization recommendation. Match detail level to impact — critical issues deserve thorough explanation.
-```
-
-**Teammate 3: Test Coverage Reviewer**
-
-```
-You are conducting a test coverage review as part of a PR review team.
-
-PR TITLE: {literal PR title}
-PR AUTHOR: {literal author}
-BASE BRANCH: {literal base branch}
-HEAD BRANCH: {literal head branch}
-
-DIFF SUMMARY:
-{literal git diff --stat output}
-
-CHANGED FILES:
-{literal list of changed files}
-
-[If ≤50 files]
-CHANGED FILE CONTENTS:
-{literal file contents}
-
-[If >50 files]
-Note: This PR has >50 changed files. Use the Read tool to examine specific files you need to review for test coverage.
-
-PR DESCRIPTION:
-{literal PR body}
-
-YOUR TASK:
-Review this PR for test adequacy and quality. Assess whether the test suite adequately covers the changes and would catch regressions.
-
-Judgment criteria for gap severity:
-- Critical: Core functionality completely untested (e.g., new API endpoint with no tests, auth logic without coverage)
-- High: Important edge cases missing (e.g., error handling paths, boundary conditions on critical logic)
-- Medium: Test exists but is shallow or brittle (e.g., only tests happy path, uses implementation details)
-- Low: Nice-to-have coverage improvements (e.g., additional assertion specificity, minor edge cases)
-
-Key questions to answer: Are tests meaningful (not just "it doesn't crash")? Do they cover error states and edge cases? Would they catch regressions if someone modifies this code later? Are tests maintainable and isolated?
-
-CROSS-CONCERN FINDINGS:
-If you find test gaps that expose security or performance risks, share via SendMessage:
-"Test Coverage: Missing tests at {file}:{line} also creates {other concern} risk — {explanation}"
-
-WORKING CONSTRAINTS:
-You're operating in a parallel review team. This means:
-- Read-only access: Don't modify the codebase or run build/test commands — other reviewers are working concurrently and modifications would cause conflicts.
-- Team communication only: Use SendMessage for cross-concern findings. You cannot interact with the user directly.
+CONSTRAINTS (parallel-team context):
+- Read-only. Don't modify the codebase or run build/test commands — other reviewers are working concurrently.
+- Communicate via `SendMessage` only; `AskUserQuestion` isn't available in team context.
 
 COMPLETION:
-When you've completed your test coverage review, mark your task complete via TaskUpdate with your findings, send "REVIEW COMPLETE" via SendMessage, and wait for shutdown_request.
+1. `TaskUpdate` your shared task with findings.
+2. `SendMessage` `REVIEW COMPLETE`.
+3. Wait for `shutdown_request`.
 
-FINDINGS GUIDANCE:
-For each gap, include file path with line numbers, severity, what test scenario is missing, and recommendation. Match detail level to severity — critical gaps deserve thorough explanation.
-```
+For each finding: `file:line`, severity, description, recommendation. Match depth to severity — critical findings deserve a traced execution path; nits deserve one line.
+</example>
 
-**Teammate 4: Architecture Reviewer**
+### Convergence
 
-```
-You are conducting an architecture-focused review as part of a PR review team.
-
-PR TITLE: {literal PR title}
-PR AUTHOR: {literal author}
-BASE BRANCH: {literal base branch}
-HEAD BRANCH: {literal head branch}
-
-DIFF SUMMARY:
-{literal git diff --stat output}
-
-CHANGED FILES:
-{literal list of changed files}
-
-[If ≤50 files]
-CHANGED FILE CONTENTS:
-{literal file contents}
-
-[If >50 files]
-Note: This PR has >50 changed files. Use the Read tool to examine specific files you need to review for architecture concerns.
-
-PR DESCRIPTION:
-{literal PR body}
-
-YOUR TASK:
-Review this PR for architectural quality and design patterns. Evaluate whether the changes follow established codebase conventions and maintain a sustainable design.
-
-Judgment criteria for impact:
-- Critical: Breaking changes to public APIs, circular dependencies introduced, or fundamental design violations that would be costly to fix later
-- High: Patterns that deviate significantly from codebase conventions, tight coupling that limits extensibility, or poor separation of concerns
-- Medium: Suboptimal design choices that work but create maintenance burden (e.g., logic in wrong layer, inconsistent abstractions)
-- Low: Style-level architectural preferences with minimal real impact
-
-Key questions to answer: Does this follow the existing codebase's patterns? Are responsibilities clearly separated? Would a new developer understand the design intent? Are there breaking changes that affect consumers?
-
-CROSS-CONCERN FINDINGS:
-If you find architectural issues that affect security, performance, or testability, share via SendMessage:
-"Architecture: This {issue} at {file}:{line} also has {other concern} implications — {explanation}"
-
-WORKING CONSTRAINTS:
-You're operating in a parallel review team. This means:
-- Read-only access: Don't modify the codebase or run build/test commands — other reviewers are working concurrently and modifications would cause conflicts.
-- Team communication only: Use SendMessage for cross-concern findings. You cannot interact with the user directly.
-
-COMPLETION:
-When you've completed your architecture review, mark your task complete via TaskUpdate with your findings, send "REVIEW COMPLETE" via SendMessage, and wait for shutdown_request.
-
-FINDINGS GUIDANCE:
-For each issue, include file path with line numbers, impact level, architectural concern, and improvement recommendation. Match detail level to impact — critical issues deserve thorough explanation.
-```
-
-### Completion Protocol
-
-Wait for all 4 teammates to signal completion by sending "REVIEW COMPLETE" messages. Timeout: 10 minutes from teammate spawn time.
-
-**If timeout occurs**: Proceed with available findings and note which teammates timed out in the consolidated review.
-
-**Fallback behavior**: If a teammate fails or gets stuck (repeated similar messages, no progress), you have three options:
-1. Note the failure and proceed with other teammates' findings
-2. Spawn a replacement teammate with clearer scoped instructions
-3. Handle that review aspect yourself
-
-Choose based on how critical that specialized review is to the overall PR assessment.
+Wait for all four `REVIEW COMPLETE` messages, up to 10 minutes per teammate from spawn. On teammate timeout, consolidate with whatever arrived and note which dimension is missing — a partial review is more useful than no review. If a teammate is stuck (repeated messages, no progress): note the failure, respawn with tighter scope, or absorb that dimension into the lead — pick on criticality.
 
 ### Consolidation
 
-As team lead, integrate teammate findings into a comprehensive PR review. Your job is to synthesize specialized findings into the same output structure used in Standard Workflow, not mechanically merge outputs.
+Same find/filter discipline as standard workflow, but with reviewer attribution: `[Security]`, `[Performance]`, `[Test Coverage]`, `[Architecture]`, or `[Consensus]` when two or more reviewers flagged the same area. Cross-cutting findings get their own callout:
 
-**Reviewer Attribution**: Mark which teammate(s) found each issue: `[Security]`, `[Performance]`, `[Test Coverage]`, `[Architecture]`. Mark independently confirmed findings from multiple reviewers `[Consensus]`.
+> `[Consensus]` The dependency update at `package.json:42` raises both security concerns (known CVE) and performance concerns (increased bundle size).
 
-**Output Format**: Use the same review structure as Standard Workflow Phase 3:
-- Executive Summary (synthesize risk level based on all reviewer findings)
-- Code Quality Analysis (incorporate findings from all specialized reviews)
-- Detailed File-by-File Review (merge findings by file, preserve all reviewer attributions)
-- Discussion & CI Review (same as standard workflow)
-- Testing Verification (same as standard workflow)
-- Recommendations & Action Items (merge and prioritize findings from all reviewers)
+Output format is identical to standard — the user shouldn't need to know which mode ran.
 
-**Cross-cutting Findings**: When findings from multiple reviewers relate to the same code location, highlight this:
-"[Consensus] The dependency update at package.json:42 raises both security concerns (known CVE) and performance concerns (increased bundle size)"
+### Cleanup invariant
 
-### Resource Cleanup
+**The team must be deleted before the command returns, regardless of whether consolidation succeeded.** Skipping leaks team slots and orphans the shared task list.
 
-After completing consolidation (whether successful or failed), always clean up team resources.
+1. `SendMessage` `type: "shutdown_request"` to each teammate.
+2. Wait briefly for shutdown confirmations.
+3. `TeamDelete`.
 
-Send shutdown requests to all teammates via `SendMessage` with `type: "shutdown_request"`, wait briefly for confirmations, then call `TeamDelete` to remove the team and its task list.
-
-If cleanup itself fails, inform the user: "Team cleanup incomplete. You may need to check for lingering team resources."
-
-Execute cleanup regardless of consolidation outcome—even if earlier steps errored or teammates timed out, cleanup must run before ending.
+If cleanup itself errors, tell the user `"Team cleanup incomplete. You may need to check for lingering team resources."` and continue to output.
 
 ---
 
-## Standard Workflow
+## Interactive follow-up
 
-The default PR review approach for comprehensive single-agent analysis.
+After the report, offer the user:
+- Deep-dive into a specific file.
+- Run the test suite (if the repo has a clear test command) to verify the PR claims.
+- Search the codebase for similar patterns elsewhere.
+- Draft a GitHub review comment from the findings.
 
-### Phase 1: PR Information Gathering
+These are optional — the primary output is the report.
 
-When the user provides a PR number or URL:
+## Error responses
 
-1. **Extract PR identifier**:
-   - If given URL: Extract owner/repo/number
-   - If given number: Use current repo context
-   - If given format like "owner/repo#123": Parse accordingly
+Keep the user unblocked:
 
-2. **Fetch PR metadata using GitHub CLI**:
-   ```bash
-   # Get PR details
-   gh pr view {PR_NUMBER} --json title,body,state,author,headRefName,baseRefName,url,commits,reviews,comments,labels,milestone
-
-   # Get PR diff
-   gh pr diff {PR_NUMBER}
-
-   # Get PR comments (both review comments and issue comments)
-   gh pr view {PR_NUMBER} --comments
-
-   # Get PR checks/CI status
-   gh pr checks {PR_NUMBER}
-   ```
-
-3. **Checkout PR branch locally**:
-   ```bash
-   # Fetch the PR branch
-   gh pr checkout {PR_NUMBER}
-
-   # Get current branch name for reference
-   git branch --show-current
-   ```
-
-### Phase 2: Comprehensive Analysis
-
-1. **Compare against base branch**:
-   ```bash
-   # Get the base branch (usually main/master)
-   BASE_BRANCH=$(gh pr view {PR_NUMBER} --json baseRefName -q .baseRefName)
-
-   # Show diff summary
-   git diff $BASE_BRANCH...HEAD --stat
-
-   # Show full diff
-   git diff $BASE_BRANCH...HEAD
-   ```
-
-2. **Analyze commit history**:
-   ```bash
-   # Show commits in this PR
-   git log $BASE_BRANCH..HEAD --oneline --no-merges
-
-   # Detailed commit messages
-   git log $BASE_BRANCH..HEAD --no-merges
-   ```
-
-3. **Review file changes systematically**:
-   - Read all changed files using Read tool
-   - Pay special attention to:
-     - New files (understand their purpose)
-     - Deleted files (understand why removed)
-     - Modified files (understand what changed and why)
-     - Test files (verify test coverage)
-     - Documentation (check if updated appropriately)
-
-4. **Analyze discussion context**:
-   - Review all PR comments and conversations
-   - Note any unresolved discussions
-   - Identify patterns in review feedback
-   - Check if CI/CD checks are passing
-   - Review any linked issues
-
-### Phase 3: Generate Comprehensive Review
-
-Provide a structured review covering:
-
-#### 1. Executive Summary
-- **PR Purpose**: Brief description of what this PR does
-- **Change Scope**: High-level categorization (bugfix, feature, refactor, docs, etc.)
-- **Risk Level**: Low/Medium/High based on scope and complexity
-- **Recommendation**: Approve / Request Changes / Comment
-
-#### 2. Code Quality Analysis
-- **Architecture & Design**: Does it follow project patterns?
-- **Code Style**: Consistent with project conventions?
-- **Testing**: Adequate test coverage? Tests passing?
-- **Documentation**: Inline comments, docstrings, README updates?
-- **Error Handling**: Proper error handling and edge cases?
-- **Performance**: Any performance implications?
-- **Security**: Any security concerns?
-
-#### 3. Detailed File-by-File Review
-For each changed file:
-- **File**: `path/to/file.ext`
-- **Change Type**: Added/Modified/Deleted
-- **Purpose**: Why this file changed
-- **Review Notes**: Specific feedback
-- **Issues Found**: List any problems
-- **Suggestions**: Improvement recommendations
-
-#### 4. Discussion & CI Review
-- **Unresolved Conversations**: List any open threads
-- **CI/CD Status**: All checks passing? Any failures?
-- **Review Comments**: Summary of existing review feedback
-- **Action Items**: What needs to be addressed?
-
-#### 5. Testing Verification
-If appropriate and safe:
-```bash
-# Run tests to verify nothing breaks
-# (Only if the repo has clear test commands)
-# Example: npm test, pytest, cargo test, etc.
+```
+PR not found          — Verify PR number/URL; `gh pr list` to browse.
+Not authenticated     — Run: gh auth login
+Uncommitted changes   — Stash or commit before `gh pr checkout`.
+Merge conflicts       — Note conflicts; suggest resolving before review.
+Network issue         — Suggest retry or manual `gh` command.
 ```
 
-#### 6. Recommendations & Action Items
-Clear list of:
-- **Must Fix**: Blocking issues
-- **Should Fix**: Important but not blocking
-- **Consider**: Nice-to-have improvements
-- **Praise**: What's done well
+## Safety
 
-### Phase 4: Interactive Review Session
+Never auto-commit, auto-push, or run destructive git operations. This command is pure analysis — changes come from the PR author following the findings, not from the reviewer.
 
-After providing the initial review, offer to:
-1. **Deep dive into specific files**: "Which file would you like me to examine more closely?"
-2. **Run tests**: "Should I run the test suite to verify changes?"
-3. **Check for patterns**: "Should I search for similar code patterns elsewhere in the codebase?"
-4. **Draft review comment**: "Would you like me to draft a GitHub review comment?"
-5. **Create follow-up tasks**: "Should I note any follow-up work needed?"
-
-## Usage Examples
+## Usage
 
 ```bash
-# Review a PR by number (in current repo)
-/review-pr 123
-
-# Review a PR by URL
-/review-pr https://github.com/owner/repo/pull/456
-
-# Review a PR with repo context
-/review-pr owner/repo#789
+/review-pr 123                                              # current repo
+/review-pr https://github.com/owner/repo/pull/456           # any repo
+/review-pr owner/repo#789                                   # explicit repo
+/review-pr 123 --swarm                                      # parallel specialized reviewers
 ```
-
-## Important Notes
-
-- **Branch Safety**: This command checks out the PR branch. Warn if there are uncommitted changes.
-- **GitHub Authentication**: Requires `gh` CLI to be authenticated (`gh auth status`)
-- **Repository Context**: Must be run from within a git repository or provide full PR URL
-- **Large PRs**: For PRs with many files (>20), ask which files to prioritize
-- **Private Repos**: Respects GitHub permissions via `gh` CLI authentication
-
-## Error Handling
-
-Handle common scenarios:
-- PR doesn't exist: Verify PR number/URL
-- Not authenticated: Prompt user to run `gh auth login`
-- Uncommitted changes: Ask user to commit or stash first
-- Merge conflicts: Note conflicts and suggest resolution
-- Network issues: Suggest retry or manual `gh` command
-
-## Output Format
-
-Use clear markdown formatting:
-- **Section headers** for organization
-- `Code blocks` for commands and code snippets
-- **Bold** for important findings
-- Bullet lists for readability
-- File paths with line references when specific: `path/to/file.py:42`
-
-## Commit Message Convention Awareness
-
-Check if the repo uses conventional commits (feat:, fix:, docs:, etc.) and verify PR title/commits follow the pattern.
-
-## Follow Project Conventions
-
-Before reviewing, check for:
-- `CONTRIBUTING.md` - Review guidelines
-- `CLAUDE.md` - Project-specific instructions
-- `.github/PULL_REQUEST_TEMPLATE.md` - PR template requirements
-- CI configuration - Understanding what checks run
-
-Read these files first to understand project-specific review criteria.
-
-## Rules
-
-### Prioritization
-
-**High Priority** (review first):
-- File/line-specific changes with significant impact
-- Security-related changes
-- Breaking changes or API modifications
-- Test coverage and quality
-- Documentation completeness
-
-**Lower Priority**:
-- Style/formatting issues
-- Minor refactoring
-- Comment improvements
-
-### Safety
-
-- **No automatic git operations**: Never auto-commit or push
-- **Show findings clearly**: Use structured format for easy scanning
-- **Preserve context**: Understand the full picture before suggesting changes
-- **Ask when unclear**: Use AskUserQuestion if anything is ambiguous
-
-### Best Practices
-
-- Start with understanding the PR's purpose and context
-- Review commits chronologically to understand the development flow
-- Check for consistency with existing codebase patterns
-- Verify test coverage matches the scope of changes
-- Ensure documentation is updated alongside code changes
-- Look for common pitfalls: error handling, edge cases, security issues

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-plugin",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "GitHub CI/CD automation plugin for Claude Code",
   "private": true,
   "type": "module",

--- a/scripts/validate-plugin.ts
+++ b/scripts/validate-plugin.ts
@@ -18,12 +18,13 @@ const PluginManifestSchema = z.object({
   repository: z.string().url().optional(),
   license: z.string().optional(),
   keywords: z.array(z.string()).optional(),
-  commands: z.record(z.object({
+  commands: z.record(z.string(), z.object({
     description: z.string().optional(),
-  })).optional(),
+  }).passthrough()).optional(),
   agents: z.array(z.string()).optional(),
-  hooks: z.union([z.string(), z.record(z.any())]).optional(),
-  mcpServers: z.union([z.string(), z.record(z.any())]).optional(),
+  skills: z.array(z.string()).optional(),
+  hooks: z.union([z.string(), z.record(z.string(), z.any())]).optional(),
+  mcpServers: z.union([z.string(), z.record(z.string(), z.any())]).optional(),
 });
 
 async function validatePlugin() {

--- a/skills/ci-fix-loop/SKILL.md
+++ b/skills/ci-fix-loop/SKILL.md
@@ -3,287 +3,154 @@ name: ci-fix-loop
 description: Autonomous CI fix loop with background monitoring and retry logic. Runs up to 10 fix-commit-push-wait cycles until CI passes or max retries reached.
 ---
 
-# CI Fix Loop Skill
+# CI Fix Loop
 
-Orchestrates autonomous CI repair: analyze → fix → commit → push → monitor → repeat until success.
+## Role
 
-## When to Use
+Drive an autonomous CI-repair cycle: analyze the latest failure, apply fixes, commit, push, wait for the new CI run, and loop until CI passes or the retry budget is exhausted. The point is to free the user from babysitting a CI run that's failing on fixable errors (formatting, obvious lint, easy test fixes).
 
-This skill is invoked when:
-- User runs `/fix-ci --loop` or `/fix-ci --auto`
-- User runs `/fix-ci --swarm`
-- Multiple CI fix iterations are needed
-- User wants hands-off CI repair
+Invoked by `/fix-ci --loop`, `/fix-ci --auto`, or `/fix-ci --swarm`.
 
-## CRITICAL: Parse Flags First
+## Priorities
 
-BEFORE proceeding to Phase 1, extract these flags from `$ARGUMENTS`:
-- `--swarm`: If present, set SWARM_MODE=true. You MUST remember this flag — it changes behavior at Step 2.5 (parallel team-based fixing).
-- `--loop` or `--auto`: Standard autonomous mode.
-- Remove all extracted flags from arguments; remaining text is additional context.
+Correct fix (no suppressed signal) > Forward progress (commit and push every iteration) > Termination (bail when progress stalls)
+
+## Invariants
+
+- **Don't run on `main` / `master`.** Autonomous loops that push to a protected branch are dangerous even when the fixes are right. Abort and suggest a hotfix branch.
+- **Stash before starting.** Preserve the user's in-progress work; restore on termination regardless of outcome.
+- **Bail when progress stalls.** If the same errors reappear across two consecutive attempts, the loop isn't converging — human intervention beats burning more CI budget.
+- **Budget caps are hard.** Maximum 10 attempts; maximum 30 minutes per CI run; maximum 2 minutes waiting for a new run to start after push. Each limit exists because the failure mode beyond it is worse than stopping here.
+- **Never `--no-verify` a commit.** Local hooks catch classes of regressions that CI won't; skipping them lets bugs slip into the loop itself.
+
+## Flag parsing
+
+Before anything else, extract flags from `$ARGUMENTS`:
+- `--loop` or `--auto` → standard autonomous mode.
+- `--swarm` → parallel fix mode (see below). Remember this choice — it affects how fixes are applied in each attempt.
+
+Strip consumed flags; anything remaining is contextual (e.g., a PR number).
 
 ## Configuration
 
-| Setting | Value | Description |
-|---------|-------|-------------|
-| max_attempts | 10 | Maximum fix iterations |
-| poll_interval | 60 | Seconds between CI status checks |
-| ci_start_timeout | 120 | Seconds to wait for CI run to start |
-| ci_run_timeout | 1800 | Max seconds to wait for CI completion (30 min) |
+| Setting | Value | Reason |
+|---|---|---|
+| `max_attempts` | 10 | Beyond this, compounding failures usually mean the root cause isn't code |
+| `poll_interval` | 60s | CI status doesn't change faster than this anyway |
+| `ci_start_timeout` | 120s | If CI hasn't started in 2 min, the workflow's likely misconfigured |
+| `ci_run_timeout` | 1800s (30 min) | Longer runs usually indicate infra flake, not a fixable error |
 
-## Workflow
-
-### Phase 1: Initialize
-
-Get context and validate:
+## Initialization
 
 ```bash
 BRANCH=$(git branch --show-current)
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "unknown")
 ```
 
-**Safety checks:**
-
-1. Block on protected branches:
+Guard on protected branches:
 ```bash
 if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
-  echo "Cannot run autonomous fixes on $BRANCH"
-  echo "Create a feature branch: git checkout -b fix/ci-errors"
-  # STOP - do not proceed
+  echo "Cannot run autonomous fixes on $BRANCH. Create a feature branch: git checkout -b fix/ci-errors"
+  # abort
 fi
 ```
 
-2. Handle uncommitted changes:
+Stash uncommitted changes:
 ```bash
 if [[ -n $(git status --porcelain) ]]; then
-  echo "Stashing uncommitted changes..."
   git stash push -m "pre-ci-fix-loop-$(date +%Y%m%d_%H%M%S)"
 fi
 ```
 
-Initialize state:
-```
-attempt = 1
-max_attempts = 10
-last_errors = []
-history = []
-started_at = now
-```
+Start the loop with `attempt=1`, `last_errors=[]`, `history=[]`, `consecutive_same_errors=0`.
 
-### Phase 2: Fix Loop
+## Iteration
 
-For each attempt from 1 to 10:
+Each attempt follows the same shape. The sequence matters — commit must come after fix, push must come after commit, monitor must come after push — but within those boundaries the model picks the tactics. Don't over-narrate each step.
 
-#### Step 2.1: Display Progress
+### Fetch and analyze
 
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-CI Fix Loop - Attempt ${attempt}/${max_attempts}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Branch: ${branch}
-Repository: ${repo}
-```
+Pull the latest failed run on this branch, fetch logs for every failed job, and hand them to the `ci-log-analyzer` agent. The agent returns a structured error list (category, file, line, message). Trust that output — re-parsing logs wastes context.
 
-#### Step 2.2: Fetch CI Logs
-
-Get most recent failed run:
 ```bash
 RUN_ID=$(gh run list --branch "$BRANCH" --limit 5 --json databaseId,conclusion \
   --jq '[.[] | select(.conclusion == "failure")][0].databaseId')
-
-if [ -z "$RUN_ID" ]; then
-  echo "No failed runs found - checking if CI is passing..."
-  # May already be fixed, verify
-fi
-```
-
-Fetch logs for failed jobs:
-```bash
 FAILED_JOBS=$(gh run view $RUN_ID --json jobs --jq '.jobs[] | select(.conclusion == "failure") | .databaseId')
-
 for JOB_ID in $FAILED_JOBS; do
   gh api repos/${REPO}/actions/jobs/${JOB_ID}/logs > /tmp/ci-logs-${JOB_ID}.txt 2>/dev/null || true
 done
 ```
 
-#### Step 2.3: Analyze Errors
+If no failed runs exist, CI might already be passing — skip to monitoring to confirm.
 
-Invoke the `ci-log-analyzer` agent:
-- Parse CI logs from /tmp/ci-logs-*.txt
-- Extract structured error list with type, file, line, message
-- Returns JSON with errors categorized by type (lint/test/type/build)
+### Termination check (no progress)
 
-#### Step 2.4: Check for Progress
+Compare the current error list to `last_errors`. If they're identical after at least one fix attempt, increment `consecutive_same_errors`. At 2, exit the loop — the fixes aren't landing or the errors are beyond what this skill can handle. Report the persistent errors in the final summary; human intervention is the right move.
 
-Compare current errors with previous attempt:
+### Apply fixes
 
-```
-if current_errors == last_errors AND attempt > 1:
-  # Same errors after fix attempt = likely unfixable
-  consecutive_same_errors += 1
+Default path: single `ci-error-fixer` agent handles the whole error list sequentially. Appropriate when errors are in one or two files, or when swarm mode wasn't requested.
 
-  if consecutive_same_errors >= 2:
-    echo "Same errors detected after 2 fix attempts - aborting"
-    echo "These errors may require manual intervention"
-    # STOP - exit loop with failure report
-fi
+**Swarm path** — triggered when `--swarm` was set *and* errors span 2+ distinct files:
 
-if current_errors is empty:
-  # No errors found - CI might be passing
-  # Skip to monitoring phase
-```
+Split the error list into up to 4 partitions by file (grouping by directory proximity if there are more than 4 files). Non-file-specific errors (dependency resolution, config, flaky tests without file association) stay with the lead for sequential handling.
 
-#### Step 2.5: Apply Fixes
+Create the team with `TeamCreate`: name `fix-ci-{YYYYMMDD-HHMMSS}`, description `CI Fix Attempt {attempt}`. If `TeamCreate` is unavailable (experimental flag off), fall back to the single-agent path — surface the fallback in logs but don't abort the attempt.
 
-**CRITICAL Condition Check**: Before applying fixes, check BOTH conditions — was `--swarm` set during flag parsing above, AND are errors in 2+ files?
+Spawn one teammate per partition via `Task` with `team_name` and `subagent_type: "general-purpose"`. Teammates can't see this conversation — embed partition details as literal text.
 
-```
-file_count = count of distinct files with errors
-use_swarm = (file_count >= 2) AND (SWARM_MODE is true from "Parse Flags First" above)
-```
-
-**If use_swarm is FALSE** (errors in single file OR --swarm not requested):
-- Invoke the `ci-error-fixer` agent with error list
-- Applies targeted fixes based on error type
-- Shows diffs for each change
-- Reports fixed vs flagged-for-manual-review counts
-- Track results:
-  ```
-  errors_fixed = count of successfully fixed errors
-  errors_flagged = count of errors needing manual review
-  ```
-
-**If use_swarm is TRUE** (2+ files with errors AND --swarm flag set):
-
-**Team Prerequisites and Fallback**:
-
-Attempt to create the agent team using `TeamCreate` with a unique timestamped name: `fix-ci-{YYYYMMDD-HHMMSS}` and description: "CI Fix Attempt {attempt}".
-
-If team creation fails (tool unavailable or experimental features disabled), inform the user that swarm mode requires agent teams to be enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in settings.json), then fall back to the standard (non-swarm) fix approach using the existing `ci-error-fixer` agent as above.
-
-**Partitioning Strategy** (performed by lead after centralized analysis in Step 2.3):
-
-1. Group errors by file path (deterministic: sort errors by file path first)
-2. If >4 distinct files, group by directory proximity to create max 4 partitions
-3. Non-file-specific errors (dependency resolution, config issues, flaky tests without clear file association) remain with lead for sequential handling
-4. Each partition contains: error list for those files, file paths, error types and messages
-
-**Teammate Spawn Protocol** (max 4 teammates, one per file partition):
-
-Spawn each teammate via the `Task` tool with `team_name` parameter and `subagent_type: "general-purpose"`. Each teammate prompt MUST include as string literals:
-
-```
+<example name="Fix-loop teammate prompt">
 You are fixing CI errors for a specific set of files as part of a parallel fix team.
 
 YOUR FILE PARTITION:
-{list of file paths assigned to this teammate}
+{literal list of file paths}
 
 ERRORS TO FIX:
-{error list for your files - type, file, line, message}
+{literal error list for these files — type, file, line, message}
 
 FILE CONTENTS:
-{Read and include relevant file contents}
+{read each file and include its full contents here}
 
-YOUR TASK:
-Fix all errors in your assigned files. Apply targeted fixes based on error type:
-- Lint errors: auto-fix with formatter/linter where possible
-- Type errors: add type annotations, fix type mismatches
-- Test failures: fix test logic or implementation bugs
-- Build errors: fix import paths, missing dependencies
+Apply targeted fixes per error type: lint with the formatter or linter, type errors with correct annotations or mismatch fixes, test failures with corrected logic or implementation bugs, build errors with import/dependency fixes.
 
-WORKING CONSTRAINTS:
-You're one of several agents editing files in parallel. This means:
-- Edit only your assigned files — the lead handles git staging and commits to avoid conflicts between teammates.
-- Don't run tests or builds — they'd interfere with other teammates' file changes happening concurrently.
-- Communicate only via SendMessage (no user interaction available in team context).
-- Make minimal, targeted fixes — over-editing risks introducing new errors and makes the lead's review harder.
-- Read files completely without limit/offset so you don't miss relevant context.
+Constraints (parallel-team context):
+- Edit only your assigned files. The lead handles staging and commits to avoid conflicts.
+- Don't run tests or builds — other teammates are editing concurrently.
+- Communicate via `SendMessage` only; `AskUserQuestion` isn't available in team context.
+- Make minimal, targeted fixes. Over-editing introduces new errors and complicates the lead's review.
+- Read files completely, no limit/offset.
 
-COMPLETION SIGNAL:
-When you've fixed all errors in your files:
-1. Send "FIX COMPLETE" via SendMessage
-2. Wait for shutdown_request
+When every error in your partition is fixed:
+1. `SendMessage` `FIX COMPLETE`.
+2. Wait for `shutdown_request`.
+</example>
 
-ERROR TYPES AND HANDLING:
-{specific guidance based on error types in this partition}
-```
+Wait for every teammate's `FIX COMPLETE`, up to 10 minutes per teammate from spawn. On timeout, proceed with available fixes and note it in the history. After teammates complete (or time out), the lead stages all changes in one commit (below) rather than per-teammate.
 
-**Completion Protocol**:
+**Cleanup invariant** — regardless of swarm success or failure, `SendMessage` `type: "shutdown_request"` to each teammate, wait briefly, then `TeamDelete`. Skipping leaks team slots.
 
-Wait for all teammates to signal completion by sending "FIX COMPLETE" messages. Timeout: 10 minutes from teammate spawn time.
+### Commit and push
 
-If timeout occurs, proceed with available fixes and note which teammates timed out.
-
-**Lead Collects Changes**:
-
-After all teammates complete (or timeout), the lead stages ALL changes in a single commit and single push:
+One commit per iteration — captures the full fix for this attempt in a single reviewable unit:
 
 ```bash
 git add .
-
-git commit -m "fix(ci): automated swarm fix attempt ${attempt}
-
-Errors addressed across ${file_count} files:
-- ${error_summary_list}
-
-Attempt ${attempt} of ${max_attempts} (ci-fix-loop with swarm)"
-```
-
-This replaces the per-error serial commits from the non-swarm approach.
-
-Push to trigger CI (swarm mode):
-```bash
-PUSH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-git push origin ${BRANCH}
-```
-
-**Resource Cleanup**:
-
-Always execute cleanup regardless of success or failure:
-1. Send shutdown requests to all teammates via `SendMessage` with `type: "shutdown_request"`
-2. Wait briefly for confirmations
-3. Call `TeamDelete` to remove the team
-
-If cleanup fails, log warning: "Team cleanup incomplete. You may need to check for lingering team resources."
-
-Execute cleanup before proceeding to Step 2.6.
-
-**Track Results**:
-```
-errors_fixed = count of successfully fixed errors across all teammates
-errors_flagged = count of errors needing manual review
-```
-
-**Note**: The team is created and torn down within this single fix iteration (Step 2.5). The outer loop (Phase 2) continues as normal after this step completes.
-
-#### Step 2.6: Commit & Push
-
-**Note**: If swarm mode was used in Step 2.5, the commit and push were already performed by the lead after collecting teammate changes. Skip this step and proceed to Step 2.7.
-
-**Otherwise** (standard non-swarm mode):
-
-Stage and commit changes:
-```bash
-git add .
-
-# Create descriptive commit message
 git commit -m "fix(ci): automated fix attempt ${attempt}
 
 Errors addressed:
 - ${error_summary_list}
 
-Attempt ${attempt} of ${max_attempts} (ci-fix-loop)"
-```
+Attempt ${attempt} of ${max_attempts} (ci-fix-loop${SWARM_SUFFIX})"
 
-Push to trigger CI:
-```bash
 PUSH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 git push origin ${BRANCH}
 ```
 
-#### Step 2.7: Wait for CI Run to Start
+`PUSH_TIME` is used below to detect the new run (distinguishing it from the run currently being analyzed). In swarm mode the lead owns this step — teammates never run git commands, which keeps coordination simple.
 
-Use the Monitor tool to detect when a new CI run appears after the push:
+### Wait for the new run to start
+
+Use the `Monitor` tool (no LLM tokens burned on polling) to watch for a run created after `PUSH_TIME`, capped at `ci_start_timeout`:
 
 ```
 Monitor:
@@ -306,13 +173,13 @@ Monitor:
     done
 ```
 
-**Notification handling:**
-- `STARTED|{RUN_ID}` → capture `NEW_RUN_ID`, proceed to Step 2.8
-- Monitor timeout (no notification within 120s) → warn "No CI run started after 120s — check if workflows are enabled for this branch", proceed to Step 2.9 with `TIMEOUT`
+Notifications:
+- `STARTED|{RUN_ID}` → capture as `NEW_RUN_ID`, proceed to monitoring.
+- Monitor timeout (no notification within 120s) → warn `"No CI run started after 120s — check if workflows are enabled for this branch"` and proceed with `TIMEOUT`.
 
-#### Step 2.8: Monitor CI Completion
+### Monitor to terminal state
 
-Use the Monitor tool to track the CI run until terminal state. When `NEW_RUN_ID` is known from Step 2.7, filter by that specific run to avoid race conditions with concurrent runs:
+Run the `Monitor` tool again, filtered by `NEW_RUN_ID` when known (avoids race conditions with concurrent runs on the same branch):
 
 ```
 Monitor:
@@ -356,142 +223,73 @@ Monitor:
     done
 ```
 
-**Notification handling:**
-- `SUCCESS|{RUN_ID}` → proceed to Step 2.9 with success
-- `FAILURE|{RUN_ID}` → proceed to Step 2.9 with failure (triggers next fix iteration)
-- `CANCELLED|{RUN_ID}` → warn "CI run was cancelled externally" and exit loop
-- `ACTION_REQUIRED|{RUN_ID}` → warn user that manual approval is needed, exit loop
-- Monitor timeout (30 min) → treat as `TIMEOUT|unknown`, report and suggest `gh run watch`
+Handle the result:
+- **SUCCESS** — exit the loop, report success.
+- **FAILURE** — record history, `last_errors = current_errors`, `attempt += 1`, back to `Fetch and analyze`.
+- **CANCELLED** — warn and exit. Someone (or something) cancelled the run externally; continuing would loop indefinitely.
+- **ACTION_REQUIRED** — warn the user that manual approval is needed and exit.
+- **TIMEOUT** (30 min) — report and suggest `gh run watch`; offer continue-waiting vs. abort — long CI runs usually indicate infrastructure issues, not fixable errors.
 
-#### Step 2.9: Handle Result
+### Record
 
-Parse monitor output:
+Append to history:
 ```
-case "$RESULT" in
-  SUCCESS*)
-    # CI passed! Exit loop with success
-    ;;
-  FAILURE*)
-    # CI still failing - continue to next attempt
-    ;;
-  CANCELLED*)
-    # Run was cancelled - warn and exit
-    echo "CI run was cancelled externally"
-    # EXIT with warning
-    ;;
-  TIMEOUT*)
-    # Exceeded 30 min wait
-    echo "CI run timed out after 30 minutes"
-    # Ask if should continue waiting or abort
-    ;;
-esac
+{attempt, errors_found, errors_fixed, errors_flagged, run_id, result, duration}
 ```
 
-#### Step 2.10: Record History
+## Final report
+
+On exit — success, failure, or abort — produce:
 
 ```
-history.append({
-  attempt: attempt,
-  errors_found: len(current_errors),
-  errors_fixed: errors_fixed,
-  errors_flagged: errors_flagged,
-  run_id: run_id,
-  result: conclusion,
-  duration: attempt_duration
-})
-
-last_errors = current_errors
-attempt += 1
-```
-
-### Phase 3: Final Report
-
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 CI Fix Loop Complete
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Result: [SUCCESS|FAILURE] after ${attempts} attempt(s)
-
-Summary:
-  Total time: ${total_duration}
-  Commits created: ${commit_count}
-  Errors fixed: ${total_errors_fixed}
+Result: SUCCESS | FAILURE | ABORTED after {attempts} attempt(s)
+Total time: {duration}
+Commits created: {count}
+Errors fixed: {total}
 
 History:
+  Attempt 1: Found 5 errors, fixed 5 → FAILURE (5 new errors surfaced after first fix)
+  Attempt 2: Found 5 errors, fixed 3 → SUCCESS
+  ...
 ```
 
-For each entry in history:
+**On failure** — surface what's left so the human knows where to pick up:
 ```
-  Attempt ${n}: Found ${errors_found} errors, fixed ${fixed} → ${result}
-```
+Remaining issues (need manual intervention):
+  - src/x.ts:42 — type mismatch on return value (error persisted across 2 attempts)
 
-If FAILURE:
-```
-Remaining Issues (require manual intervention):
-  - ${file}:${line} - ${message}
-    Type: ${type}
-
-Suggested next steps:
-  1. Review errors above
-  2. Check CI logs: gh run view ${last_run_id} --log-failed
-  3. Fix manually and push
+Next:
+  1. Review remaining errors above.
+  2. Inspect logs: gh run view {last_run_id} --log-failed
+  3. Fix manually and push.
 ```
 
-If SUCCESS:
+**On success** — report the commit trail so the user can squash or review:
 ```
-CI is now passing!
+CI is now passing.
 
-Next steps:
-  1. Review automated commits: git log --oneline -${commit_count}
-  2. Squash if desired: git rebase -i HEAD~${commit_count}
-  3. Create PR: /github:create-pr
+Next:
+  1. Review commits: git log --oneline -{commit_count}
+  2. Squash if desired: git rebase -i HEAD~{commit_count}
+  3. Open PR: /github:create-pr
 ```
 
-## Error Handling
+## Error handling
 
-### Network/API Failures
-- Retry `gh` commands 3 times with 5s backoff
-- If persistent, abort and report
+- **Network / `gh` flakes** — retry the command up to 3 times with 5s backoff before treating as persistent; abort the loop if still failing.
+- **Push rejection** (upstream advanced) — don't try to resolve automatically; tell the user `"Upstream changes detected. Pull and retry: git pull --rebase && /fix-ci --loop"`.
+- **CI start timeout** (no run within 2 min) — check workflow configuration; continue to monitor just in case a delayed run appears.
+- **CI run timeout** (30 min exceeded) — offer continue-waiting vs. abort; don't silently extend.
+- **Team creation fails** (swarm only) — fall back to single-agent fix for that iteration; keep going.
 
-### Git Conflicts
-- If push fails due to upstream changes:
-```
-echo "Upstream changes detected"
-echo "Pull and retry: git pull --rebase && /fix-ci --loop"
-```
-- Abort loop
+## Safety recap
 
-### Unfixable Errors
-- Track errors persisting across 2+ attempts
-- Mark as "unfixable" in final report
-- Continue attempting other errors
-
-### Timeout
-- CI run timeout (30 min): report and suggest `gh run watch`
-- CI start timeout (2 min): check workflow configuration
-
-## Safety Mechanisms
-
-1. **Branch protection**: Never run on main/master
-2. **Max attempts**: Hard limit of 10 iterations
-3. **Stash protection**: Uncommitted changes are preserved
-4. **Progress detection**: Abort if same errors repeat twice
-5. **Timeout limits**: 30 min max CI wait per attempt
-6. **Commit tracking**: Report all commits for easy revert
-7. **Swarm mode constraints**: When using `--swarm`, teammates are restricted to file editing only - they cannot run git commands (commit/push/add), test commands, build commands, or use AskUserQuestion. This prevents coordination issues and ensures the lead maintains control of the git workflow.
-
-## Token Efficiency
-
-Estimated per iteration:
-- Analysis (sonnet): ~2000 tokens
-- Fix application (sonnet): ~3000 tokens
-- State/reporting: ~500 tokens
-- **Total: ~5500 tokens/iteration**
-- **10 iterations max: ~55,000 tokens**
-
-Key optimizations:
-- CI monitoring uses the Monitor tool (zero LLM tokens)
-- No context accumulation between iterations
-- Minimal state tracking
-- Background execution frees terminal
+The invariants section at the top is load-bearing, but the mechanics also matter:
+- Branch protection prevents protected-branch loops.
+- Stash preserves uncommitted work.
+- `consecutive_same_errors >= 2` aborts loops that aren't converging.
+- Commit log lets the user squash or revert cleanly.
+- In swarm mode, teammates edit files only — they don't run git, builds, or tests. That keeps coordination simple and prevents teammates from clobbering each other's work.
+- CI monitoring uses the `Monitor` tool rather than an LLM polling agent — zero token cost for the wait loop.


### PR DESCRIPTION
## Summary

Extends the Opus 4.7 prompt refactor from sdlc-plugin (#58, v1.29.0) and primitives-plugin (v1.13.0) to github-plugin. Four Tier 1 rewrites + two Tier 2 surgical passes. Principles captured in \`sdlc-plugin/OPUS_4_7_PROMPTING.md\`.

### Tier 1 — full rewrites

- **\`commands/address-pr-comments.md\`** (685 → ~330 lines). Flatten Phase 1.1–2.6 rigid numbering into flow-stages with stated invariants (every comment replied, one fix one commit, posted replies are permanent). Keep caps only on the genuine shell-injection security boundary; strip rule-emphasis caps everywhere else.
- **\`commands/review-pr.md\`** (533 → ~280 lines). Main win: **find/filter split** per 4.7 review guidance. Without it, 4.7 silently suppresses findings it thinks aren't important enough. Four specialized-reviewer prompts consolidated into a shared template with per-role parameterization.
- **\`commands/fix-ci.md\`** (220 → ~150 lines). Collapse Step 1–5 scaffolding into role + invariants + single-iteration workflow. Split error triage into find (\`ci-log-analyzer\` categorizes all) + filter (which to fix this iteration vs. out of scope). Explicit invariants: don't suppress test/lint signal, no \`--no-verify\`, branch protection holds.
- **\`skills/ci-fix-loop/SKILL.md\`** (451 → ~220 lines). Step 2.1–2.10 attempt loop → iteration structure + explicit termination invariants up front (10-attempt cap, 30-min per CI run, 2-min new-run wait, 2-consecutive-same-errors abort). Removed stale \`budget_tokens\`/Token Efficiency section — 4.7 uses the \`effort\` parameter.

### Tier 2 — surgical passes

- \`agents/ci-error-fixer.md\` — \`Safety Rules\` ✅/❌ checklist rewritten as reasoning-based "auto-fix vs. flag for review" section explaining *when* each fix category is unambiguous.
- \`agents/ci-log-analyzer.md\` — Step 1–7 analysis workflow flattened; pattern library preserved; added root-cause-vs-symptom guidance for cascading errors.

### Left alone (Tier 3)

\`commands/create-pr.md\`, \`commands/create-issue-from-plan.md\`, and \`agents/ci-monitor.md\` are already reasoning-prose and concise.

## Verification

- Per-plugin \`bun run validate\` — **pre-existing validator bug** on \`main\` (zod schema mismatch) not caused by this PR and not blocking. \`refactor/opus-4-7-prompt-refactor\` shows the same 4-error output as \`main\`. Fix separate from this refactor.
- Commits organized per-file for Tier 1 rewrites; Tier 2 batched; release commit bumps version + CHANGELOG.
- Grep verified: no \`temperature\`, \`top_p\`, \`top_k\`, \`budget_tokens\`, \`claude-opus-4-5\`, \`claude-opus-4-6\` references in the plugin after the refactor.

## Test plan

- [ ] Spot-check \`/review-pr\` on a real PR — confirm find/filter split produces more findings than pre-refactor, and that nits aren't suppressed.
- [ ] Spot-check \`/fix-ci --loop\` on a branch with fixable CI failures — confirm termination criteria trigger correctly.
- [ ] Spot-check \`/address-pr-comments\` on a PR with mixed comment types — confirm invariant holds (every comment gets one reply; no duplicates on re-run).

## Plan

See \`/Users/iamladi/.claude/plans/ok-we-have-done-wiggly-blum.md\` (the same plan also covered primitives-plugin, which shipped first).